### PR TITLE
Dont call .Int on non-existant hash key; Add more default ports

### DIFF
--- a/lib/URI/DefaultPort.pm
+++ b/lib/URI/DefaultPort.pm
@@ -7,13 +7,18 @@ package URI::DefaultPort {
 
     my %default_port = (
         ftp     =>      21,
+        sftp    =>      22,
         ssh     =>      22,
         telnet  =>      23,
         tn3270  =>      23,
+        smtp    =>      25,
         gopher  =>      70,
         http    =>      80,
+        shttp   =>      80,
         pop     =>      110,
         news    =>      119,
+        nntp    =>      119,
+        imap    =>      143,
         ldap    =>      389,
         https   =>      443,
         rlogin  =>      513,
@@ -24,7 +29,8 @@ package URI::DefaultPort {
         rsync   =>      873,
         mms     =>      1755,
         sip     =>      5060,
-        sips    =>      5061
+        sips    =>      5061,
+        git     =>      9418
     );
     
     our sub scheme_port(Str $scheme) {

--- a/lib/URI/DefaultPort.pm
+++ b/lib/URI/DefaultPort.pm
@@ -29,7 +29,7 @@ package URI::DefaultPort {
     
     our sub scheme_port(Str $scheme) {
         # guessing the // Int should be unnecessary some day ...
-        return  %default_port{$scheme}.Int // Int;
+        return  %default_port.exists_key($scheme) ?? %default_port{$scheme}.Int !! Int;
     }
 
 }

--- a/lib/URI/DefaultPort.pm
+++ b/lib/URI/DefaultPort.pm
@@ -35,7 +35,7 @@ package URI::DefaultPort {
     
     our sub scheme_port(Str $scheme) {
         # guessing the // Int should be unnecessary some day ...
-        return  %default_port.exists_key($scheme) ?? %default_port{$scheme}.Int !! Int;
+        return (%default_port{$scheme} // Int).Int;
     }
 
 }

--- a/t/01.t
+++ b/t/01.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 47;
+plan 48;
 
 use URI;
 ok(1,'We use URI and we are still alive');
@@ -105,4 +105,7 @@ try {
     }
 }
 is($url_2_valid, 0, 'validating parser rejected bad URI');
+
+nok(URI.new('foo://bar.com').port, '.port without default value lives');
+
 # vim:ft=perl6


### PR DESCRIPTION
* When calling .port on a scheme without a DefaultPort entry you would get the following:
`No such method 'Int' for invocant of type 'Any'` from `return %default_port{(Any)}.Int`

* Added some default port numbers.