### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/IETF/RFC_Grammar.pm
+++ b/lib/IETF/RFC_Grammar.pm
@@ -1,4 +1,4 @@
-class IETF::RFC_Grammar;
+unit class IETF::RFC_Grammar;
 
 # Thanks in part to Aaron Sherman
 # and his article http://essays.ajs.com/2010/05/writing-perl-6-uri-module.html

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -1,4 +1,4 @@
-class URI;
+unit class URI;
 
 use IETF::RFC_Grammar;
 use IETF::RFC_Grammar::URI;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.