### PR TITLE
deprecate absolute and relative URI methods

### DIFF
--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -8,7 +8,7 @@ need URI::DefaultPort;
 has $.grammar;
 has $.is_validating is rw = False;
 has $!path;
-has $!is_absolute;
+has $!is_absolute;  # part of deprecated code scheduled for removal
 has $!scheme;
 has $!authority;
 has $!query;
@@ -57,7 +57,7 @@ method parse (Str $str) {
     $!authority = $comp_container<authority>;
     $!path =    $comp_container<path_abempty>       ||
                 $comp_container<path_absolute>      ;
-    $!is_absolute = ?($!path || $!scheme);
+    $!is_absolute = ?($!path || $!scheme); # part of deprecated code
 
     $!path ||=  $comp_container<path_noscheme>      ||
                 $comp_container<path_rootless>      ;
@@ -164,12 +164,22 @@ method path {
     return ~($!path || '');
 }
 
+#`{{
+The absolute and relative methods are artifacts carried over from an old
+version of the p6 module.  The perl 5 module and does not provide such
+functionality nor does, for example, the Ruby equivalent.  The URI rfc
+does identify absolute URIs and absolute URI paths and these methods
+somewhat confused the two.  Their functionality at the URI level is no
+longer seen as needed and is being removed.
+}}
 method absolute {
-    return $!is_absolute;
+    warn 'deprecated - see comments in source';
+    return Bool.new;
 }
 
 method relative {
-    return ! $.absolute;
+    warn 'deprecated - see comments in source';
+    return Bool.new;
 }
 
 method query {
@@ -232,9 +242,6 @@ URI — Uniform Resource Identifiers (absolute and relative)
     my $query = $u.query;
     my $frag = $u.frag; # or $u.fragment;
     my $tag = $u.query_form<tag>; # should be woow
-
-    my $is_absolute = $u.absolute;
-    my $is_relative = $u.relative;
 
     # something p5 URI without grammar could not easily do !
     my $host_in_grammar =

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -164,21 +164,23 @@ method path {
     return ~($!path || '');
 }
 
-#`{{
-The absolute and relative methods are artifacts carried over from an old
-version of the p6 module.  The perl 5 module and does not provide such
-functionality nor does, for example, the Ruby equivalent.  The URI rfc
-does identify absolute URIs and absolute URI paths and these methods
-somewhat confused the two.  Their functionality at the URI level is no
-longer seen as needed and is being removed.
-}}
+my $warn-deprecate-abs-rel = q:to/WARN-END/;
+    The absolute and relative methods are artifacts carried over from an old
+    version of the p6 module.  The perl 5 module does not provide such
+    functionality.  The Ruby equivalent just checks for the presence or
+    absence of a scheme.  The URI rfc does identify absolute URIs and
+    absolute URI paths and these methods somewhat confused the two.  Their
+    functionality at the URI level is no longer seen as needed and is
+    being removed.
+WARN-END
+ 
 method absolute {
-    warn 'deprecated - see comments in source';
+    warn "deprecated -\n$warn-deprecate-abs-rel";
     return Bool.new;
 }
 
 method relative {
-    warn 'deprecated - see comments in source';
+    warn "deprecated -\n$warn-deprecate-abs-rel";
     return Bool.new;
 }
 

--- a/t/01.t
+++ b/t/01.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 48;
+plan 42;
 
 use URI;
 ok(1,'We use URI and we are still alive');
@@ -32,16 +32,9 @@ is($u.port, 443, 'default https port');
 ok(! $u._port.defined, 'no specified port');
 
 $u.parse('/foo/bar/baz');
-
 is($u.segments, 'foo bar baz', 'segments from absolute path');
-ok($u.absolute, 'absolute path');
-nok($u.relative, 'not relative path');
-
 $u.parse('foo/bar/baz');
-
 is($u.segments, 'foo bar baz', 'segements from relative path');
-ok( $u.relative, 'relative path');
-nok($u.absolute, 'not absolute path');
 
 is($u.segments[0], 'foo', 'first segment');
 is($u.segments[1], 'bar', 'second segment');
@@ -50,10 +43,7 @@ is($u.segments[*-1], 'baz', 'last segment');
 # actual uri parameter not required
 $u = URI.new;
 $u.parse('http://foo.com');
-
 ok($u.segments == 1 && $u.segments[0] eq '', ".segments return [''] for empty path");
-ok($u.absolute, 'http://foo.com has an absolute path');
-nok($u.relative, 'http://foo.com does not have a relative path');
 is($u.port, 80, 'default http port');
 
 # test URI parsing with <> or "" and spaces


### PR DESCRIPTION
Fix issue #9 relative and absolute are incorrect.  Deprecate methods relative and absolute and take out public documentation and tests.