### PR TITLE
Return an empty scheme rather than dieing.

### DIFF
--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -135,7 +135,7 @@ method new(Str $uri_pos1?, Str :$uri, :$is_validating) {
 }
 
 method scheme {
-    return ~$!scheme.lc;
+    return ~($!scheme || '').lc;
 }
 
 method authority {

--- a/t/01.t
+++ b/t/01.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 43;
+plan 44;
 
 use URI;
 ok(1,'We use URI and we are still alive');
@@ -108,5 +108,7 @@ try {
 is($url_2_valid, 0, 'validating parser rejected bad URI');
 
 nok(URI.new('foo://bar.com').port, '.port without default value lives');
+
+lives-ok { URI.new('/foo/bar').port }, '.port on relative URI lives';
 
 # vim:ft=perl6


### PR DESCRIPTION
In a number of places you may not know in advance whether
you are going to get a relative or fully qualified URI, this
saves checking a "safe" method before attempting to to use the scheme.