### PR TITLE
Remove obsolete is_validating option

### DIFF
--- a/lib/IETF/RFC_Grammar.pm
+++ b/lib/IETF/RFC_Grammar.pm
@@ -19,13 +19,13 @@ has $.grammar;
 has $.parse_result;
 
 method parse($parse_str) {
-    $!parse_result = $!grammar.parse($parse_str) or die "Parse failed";
+    $!parse_result = $!grammar.parse($parse_str);
 }
 
-method parse_validating($parse_str) {
-    $!parse_result = $!grammar.parse($parse_str, :rule<TOP-validating>)
-        or die "Parse failed";
+method subparse($parse_str) {
+    $!parse_result = $!grammar.subparse($parse_str);
 }
+
 
 submethod BUILD(:$!rfc, :$!grammar) {}
 

--- a/lib/IETF/RFC_Grammar/URI.pm
+++ b/lib/IETF/RFC_Grammar/URI.pm
@@ -12,7 +12,6 @@ unit grammar IETF::RFC_Grammar::URI:version<0.02> is IETF::RFC_Grammar::IPv6;
 
 token TOP               { <URI-reference> };
 token TOP-non-empty     { <URI> | <relative-ref-non-empty> };
-token TOP-validating    { ^ <URI-reference> $ };
 token URI-reference     { <URI> | <relative-ref> };
 
 token absolute-URI      { <scheme> ':' <.hier-part> [ '?' query ]? };

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -5,8 +5,13 @@ use IETF::RFC_Grammar::URI;
 use URI::Escape;
 need URI::DefaultPort;
 
+class X::URI::Invalid is Exception {
+    has $.source;
+    method message { "Could not parse URI: $!source" }
+}
+
 has $.grammar;
-has $.is_validating is rw = False;
+has Bool $.match-prefix = False;
 has $!path;
 has $!is_absolute;  # part of deprecated code scheduled for removal
 has $!scheme;
@@ -18,10 +23,10 @@ has $!uri;  # use of this now deprecated
 
 has @.segments;
 
-method parse (Str $str) {
+method parse (Str $str, :$match-prefix) {
 
     # clear string before parsing
-    my $c_str = $str;
+    my Str $c_str = $str;
     $c_str .= subst(/^ \s* ['<' | '"'] /, '');
     $c_str .= subst(/ ['>' | '"'] \s* $/, '');
 
@@ -29,19 +34,16 @@ method parse (Str $str) {
         $!frag = Mu;
     %!query_form = @!segments = ();
 
-    try {
-        if ($.is_validating) {
-            $!grammar.parse_validating($c_str);
-        }
-        else {
-            $!grammar.parse($c_str);
-        }
+    if ($!match-prefix or $match-prefix) {
+        $!grammar.subparse($c_str);
+    }
+    else {
+        $!grammar.parse($c_str);
+    }
 
-        CATCH {
-            default {
-                die "Could not parse URI: $str"
-            }
-        }
+    # hacky but for the time being an improvement
+    if (not $!grammar.parse_result) {
+        X::URI::Invalid.new(source => $str).throw
     }
 
     # now deprecated
@@ -117,25 +119,19 @@ method init ($str) {
 }
 
 # new can pass alternate grammars some day ...
-submethod BUILD(:$!is_validating) {
+submethod BUILD(Bool :$!match-prefix) {
     $!grammar = IETF::RFC_Grammar.new('rfc3986');
 }
 
-method new(Str $uri_pos1?, Str :$uri, :$is_validating) {
-    my $obj = self.bless;
+multi method new(Str $uri, Bool :$match-prefix) {
+    my $obj = self.bless(:$match-prefix);
 
-    if $is_validating.defined {
-        $obj.is_validating = ?$is_validating;
-    }
-
-    if $uri.defined and $uri_pos1.defined {
-        die "Please specify the uri by name or position but not both.";
-    }
-    elsif $uri.defined or $uri_pos1.defined {
-        $obj.parse($uri // $uri_pos1);
-    }
-
+    $obj.parse($uri) if $uri.defined;
     return $obj;
+}
+
+multi method new(Str :$uri, Bool :$match-prefix) {
+    return self.new($uri, :$match-prefix);
 }
 
 method scheme {
@@ -271,8 +267,14 @@ URI — Uniform Resource Identifiers (absolute and relative)
         say 'Please use registered domain name!';
     }
 
+    {
     # require whole string matches URI and throw exception otherwise ..
-    my $u_v = URI.new('http://?#?#', :is_validating<1>);# throw exception
+    my $u_v = URI.new('http://?#?#');
+    CATCH { when X::URI::Invalid { ... } }
+    }
+
+    my $u_pfx = URI.new('http://example.com } function(var mm){',
+        match-prefix => True);
 =end pod
 
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -119,18 +119,19 @@ method init ($str) {
 }
 
 # new can pass alternate grammars some day ...
-submethod BUILD(Bool :$!match-prefix) {
+submethod BUILD(:$match-prefix) {
+    $!match-prefix = ? $match-prefix;
     $!grammar = IETF::RFC_Grammar.new('rfc3986');
 }
 
-multi method new(Str $uri, Bool :$match-prefix) {
+multi method new(Str $uri, :$match-prefix) {
     my $obj = self.bless(:$match-prefix);
 
     $obj.parse($uri) if $uri.defined;
     return $obj;
 }
 
-multi method new(Str :$uri, Bool :$match-prefix) {
+multi method new(Str :$uri, :$match-prefix) {
     return self.new($uri, :$match-prefix);
 }
 

--- a/t/01.t
+++ b/t/01.t
@@ -105,7 +105,7 @@ throws-like {URI.new('http:://?#?#')}, X::URI::Invalid,
 my $uri-w-js = 'http://example.com } function(var mm){ alert(mm) }';
 throws-like {URI.new($uri-w-js)}, X::URI::Invalid,
     'URI followed by trailing javascript raises exception';
-my $uri-pfx = URI.new($uri-w-js, match-prefix => True);
+my $uri-pfx = URI.new($uri-w-js, :match-prefix);
 is(~$uri-pfx, 'http://example.com', 'Pulled of prefix URI');
 nok(URI.new('foo://bar.com').port, '.port without default value lives');
 lives-ok { URI.new('/foo/bar').port }, '.port on relative URI lives';

--- a/t/01.t
+++ b/t/01.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 46;
+plan 47;
 
 use URI;
 use URI::Escape;
@@ -99,17 +99,14 @@ is($u.query-form<foo>[1], 'trout', 'query param foo - el 2 relative path');
 $u.parse('about/perl6uri?foo=cod&foo=trout');
 is($u.query-form<foo>[1], 'trout', 'query param foo - el 2 relative path without frag');
 
-my ($url_1_valid, $url_2_valid) = (1, 1);
-try {
-    my $u_v = URI.new('http://www.perl.com', :is_validating<1>);
-    is($url_1_valid, 1, 'validating parser okd good URI');
-    $u_v = URI.new('http:://?#?#', :is_validating<1>);
-    CATCH {
-        default { $url_2_valid = 0 }
-    }
-}
-is($url_2_valid, 0, 'validating parser rejected bad URI');
+throws-like {URI.new('http:://?#?#')}, X::URI::Invalid, 
+    'Bad URI raises exception x:URI::Invalid';
 
+my $uri-w-js = 'http://example.com } function(var mm){ alert(mm) }';
+throws-like {URI.new($uri-w-js)}, X::URI::Invalid,
+    'URI followed by trailing javascript raises exception';
+my $uri-pfx = URI.new($uri-w-js, match-prefix => True);
+is(~$uri-pfx, 'http://example.com', 'Pulled of prefix URI');
 nok(URI.new('foo://bar.com').port, '.port without default value lives');
 lives-ok { URI.new('/foo/bar').port }, '.port on relative URI lives';
 


### PR DESCRIPTION
The current specification says that grammars matching is anchored by the start and end of the string.  Years ago there may have been a reason for an is_validating option but certainly no longer.  You can request a subparse by passing a match-prefix option to either new or parse.  Invalid URI exceptions now throw a class rather than a string.