### PR TITLE
Make URI::DefaultPort::scheme-port a method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp

--- a/META.info
+++ b/META.info
@@ -1,6 +1,6 @@
 {
     "name"        : "URI",
-    "version"     : "v0.1.1",
+    "version"     : "v0.1.2",
     "description" : "A URI implementation using Perl 6 grammars to implement RFC 3986 BNF",
     "depends"     : [ ],
     "provides" : {

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -148,7 +148,7 @@ method host {
 }
 
 method default-port {
-    URI::DefaultPort::scheme-port($.scheme)
+    URI::DefaultPort.scheme-port($.scheme)
 }
 method default_port { $.default-port() } # artifact form
 

--- a/lib/URI/DefaultPort.pm
+++ b/lib/URI/DefaultPort.pm
@@ -3,7 +3,7 @@ use v6;
 # This logic seems to belong somewhere related to URI but not in the URI
 # module itself.
 
-unit package URI::DefaultPort;
+unit class URI::DefaultPort;
 
 my Int %default_port = (
     ftp     =>      21,
@@ -33,8 +33,8 @@ my Int %default_port = (
     git     =>      9418
 );
     
-our sub scheme-port(Str $scheme) {
-    return %default_port{$scheme};
+method scheme-port(Str $scheme) {
+    %default_port{$scheme};
 }
 
 # vim:ft=perl6

--- a/t/lib/TestURIRequire.pm
+++ b/t/lib/TestURIRequire.pm
@@ -1,0 +1,10 @@
+use v6.c;
+
+use URI;
+
+class TestURIRequire {
+    method test(Str $uri) {
+        my $u = URI.new($uri);
+        $u.port;
+    }
+}

--- a/t/require.t
+++ b/t/require.t
@@ -1,0 +1,18 @@
+#!/usr/bin/env perl6
+
+use v6.c;
+
+use Test;
+plan 2;
+
+use lib $*PROGRAM.parent.child('lib').Str;
+
+require TestURIRequire;
+
+my $port;
+
+lives-ok { $port = ::("TestURIRequire").test('http://example.com'); }, "can use URI in a module that is itself required rather than used";
+is $port, 80, "and got the right thing back";
+
+
+done-testing;


### PR DESCRIPTION
By making URI::DefaultPort a class and scheme-port a method
it overcomes the problem when URI is used in a module which
is subsequently 'require'd

This fixes the problem I am seeing with LWP::Simple in this regard.

Fixes #30