### PR TITLE
Adding mutators and major code cleanup/documentation/test expansion

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ language: perl6
 perl6:
   - latest
 install:
-  - rakudobrew build-panda
-
+  - rakudobrew build-zef
+  - zef install --depsonly .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
 language: perl6
 perl6:
   - latest
+install:
+  - rakudobrew build-zef
+  - zef install --depsonly .

--- a/META6.json
+++ b/META6.json
@@ -11,6 +11,9 @@
         "IETF::RFC_Grammar::IPv6" : "lib/IETF/RFC_Grammar/IPv6.pm",
         "IETF::RFC_Grammar::URI"  : "lib/IETF/RFC_Grammar/URI.pm",
         "URI"                     : "lib/URI.pm",
+        "URI::Authority"          : "lib/URI.pm",
+        "URI::Path"               : "lib/URI.pm",
+        "URI::Query"              : "lib/URI.pm",
         "URI::Escape"             : "lib/URI/Escape.pm",
         "URI::DefaultPort"        : "lib/URI/DefaultPort.pm"
     },

--- a/META6.json
+++ b/META6.json
@@ -1,7 +1,8 @@
 {
     "perl"        : "6.*",
     "name"        : "URI",
-    "version"     : "v0.1.4",
+    "version"     : "v0.2",
+    "auth"        : "github:perl6-community-modules",
     "description" : "A URI implementation using Perl 6 grammars to implement RFC 3986 BNF",
     "license"     : "Artistic-2.0",
     "depends"     : [ ],

--- a/META6.json
+++ b/META6.json
@@ -3,6 +3,7 @@
     "name"        : "URI",
     "version"     : "v0.1.4",
     "description" : "A URI implementation using Perl 6 grammars to implement RFC 3986 BNF",
+    "license"     : "Artistic-2.0",
     "depends"     : [ ],
     "provides" : {
         "IETF::RFC_Grammar"       : "lib/IETF/RFC_Grammar.pm",

--- a/META6.json
+++ b/META6.json
@@ -6,6 +6,7 @@
     "description" : "A URI implementation using Perl 6 grammars to implement RFC 3986 BNF",
     "license"     : "Artistic-2.0",
     "depends"     : [ ],
+    "test-depends": [ "Test", "Test::META" ],
     "provides" : {
         "IETF::RFC_Grammar"       : "lib/IETF/RFC_Grammar.pm",
         "IETF::RFC_Grammar::IPv6" : "lib/IETF/RFC_Grammar/IPv6.pm",

--- a/README.md
+++ b/README.md
@@ -1,26 +1,812 @@
-﻿Perl6 realization of URI - Uniform Resource Identifiers handler
+NAME
+====
 
-A URI implementation using Perl 6 grammars to implement RFC 3986 BNF. 
-Currently only implements parsing.  Includes URI::Escape to (un?)escape
-characters that aren't otherwise allowed in a URI with % and a hex
-character numbering.
+URI — Uniform Resource Identifiers
+
+SYNOPSIS
+========
 
     use URI;
-    my URI $u .= new('http://her.com/foo/bar?tag=woow#bla');
-    my $scheme = $u.scheme;
-    my $authority = $u.authority;
-    my $host = $u.host;
-    my $port = $u.port;
-    my $path = $u.path;
-    my $query = $u.query;
-    my $frag = $u.frag; # or $u.fragment;
-    my $tag = $u.query-form<tag>; # should be woow
-    # etc.
+    my $u = URI.new('http://example.com/foo/bar?tag=woow#bla');
 
-    use URI::Escape;
-    my $escaped = uri-escape("10% is enough\n");
-    my $un-escaped = uri-unescape('10%25%20is%20enough%0A'); 
+    # Look at the parts
+    say $u.scheme;     #> http
+    say $u.authority;  #> example.com
+    say $u.host;       #> example.com
+    say $u.port;       #> 80
+    say $u.path;       #> /foo/bar
+    say $u.query;      #> tag=woow
+    say $u.fragment;   #> bla
 
-### Status
-[![Build Status](https://travis-ci.org/perl6-community-modules/uri.png)](https://travis-ci.org/perl6-community-modules/uri)
+    # Modify the parts
+    $u.scheme('https');
+    $u.authority('example.com:8443');
+    $u.path('/bar/foo');
+    $u.query('x=1&y=2'); # OR
+    $u.fragment('cool');
+    say "$u"; #> https://example.com:8443/bar/foo?x=1&y=2#cool
 
+    # Authority is an object, but may be undefined
+    with $u.authority {
+        say .userinfo; # none set, no output
+        say .host;     #> example.com
+        say .port;     #> 8443
+
+        # It is mutable too
+        .userinfo('bob');
+        say $u.authority; #> bob@example.com:8443
+    }
+
+    # Path is an object, always defined, but immutable
+    with $u.path {
+        say .path;          #> /bar/foo
+        .say for .segments; #> bar\nfoo\n
+    }
+
+    # Query is an object, always defined, mutable
+    with $u.query {
+        say .query;              #> x=1&y=2
+        .query('foo=1&foo=2');
+        say .query-form<foo>[0]; #> 1
+        say .query-form<foo>[1]; #> 2
+
+        .query-form.push: 'bar' => 'ok';
+        say .query;              #> foo=1&foo=2&bar=ok
+
+        .query('');
+        .query-form<abc> = 123;
+        say .query;              #> abc=123
+    }
+
+DESCRIPTION
+===========
+
+A URI object represents a parsed string that abides by the grammar defined in RFC 3986 for Universal Resource Identifiers. The object then works to enforce the rules defined in the RFC for any modifications made to it.
+
+As of this writing, The URI class is scheme agnostic. It will verify that URI is correct, in general, but not correct for a given scheme. For example, `http:foo` would be considered a valid URI even though that is not a valid URI according to the rules specific to the `http` scheme.
+
+This class uses "heavy accessors". From the SYNOPSIS, you may have noted that assignment to accessors is not used. This is because nearly all accessors in this class do some extra work of parsing, validating, and cross-referencing with other fields to guarantee that the URI is correct before making a change.
+
+    my $u = URI.new;
+    $u.path = '/foo/bar'; # ERROR: «Cannot modify an immutable URI::Path»
+    $u.path('/foo/bar');  # WORKS!
+
+This mutator pattern is meant to reflect the internal complexity.
+
+SCHEME, AUTHORITY, AND PATH
+---------------------------
+
+In RFC 3986 URIs, the scheme, the authority, and the path are related. This should not matter most of the time, but to avoid problems when setting these three, it is safest to set them in this order:
+
+    my $u = URI.new;
+    $u.path('');
+    $u.scheme($my-scheme);
+    $u.authority($my-host);
+    $u.path($my-path);
+
+This is because an empty path is permitted in any case, but the format of the path is limited whether an authority and scheme are set.
+
+With an authority set (i.e., the URI either starts with "//" or with "scheme://"), a non-empty path must start with a "/" and may start with empty path segments, e.g. "scheme://foo//" is valid.
+
+When there's no authority set, but a scheme is used (e.g., it starts with "scheme:", but not "scheme://"), a non-empty path may either start with a "/" or not, but must contain one or more other characters in the first segment of the path. Thus, the following code will fail:
+
+    my $u = URI.new('scheme:');
+    $u.path('//'); # ERROR: «Could not parse path "//" as part of URI: scheme://»
+
+When there's no authority and no scheme used, a non-empty path may start with a "/" or not, but must contain one or more other characters in the first segment.
+
+These rules are enforced whenever setting or clearing the scheme, authority, or path. If the resulting URI object would be invalid a `X::URI::Path::Invalid` exception will be thrown.
+
+QUERY
+-----
+
+The `query` method of this class returns a `URI::Query` object.This is a special object that is `Positional`, `Associative`, and `Iterable`. That is, it can be bound to an array variable, a hash variable, and iterated using a loop. If stringified, it will return a URI-encoded query. If used as an array, will act like somewhat like an array of `Pair`s. If used as a hash, will provide a map from query keys to query values.
+
+The native internal representation is a list of `Pair`s as this is the best match for how queries are defined. Because of this, there's a problem when using a query as a hash: duplicate pairs are valid. To handle this, the `URI::Query` object always returns a list of values, sorted in the order they appear for each key.
+
+For example:
+
+    my $u = URI.new('?foo=1&bar=2&foo=3');
+    say $u.query<foo>[0]; #> 1
+    say $u.query<foo>[1]; #> 3
+    say $u.query<bar>[0]; #> 2
+
+Older versions of the URI module handled this differently, using a mixed value representation. In order to gain some backwards compatibility, this is still supported by setting the `hash-format`:
+
+    # Continues from previous
+    $u.query.hash-format = URI::Query::Mixed;
+    say $u.query<foo>[0]; #> 1
+    say $u.query<foo>[1]; #> 3
+
+    # The bar value is NOT a list now
+    say $u.query<bar>;    #> 2
+
+    # Return to the default mode
+    $u.query.hash-format = URI::Query::Lists;
+
+However, the list version is safer and may likely work with most existing code that worked with mixed before.
+
+Another mode is provided to force single values, which is often how applications treat these out of convenience. In that case, only the last value will be kept:
+
+    # Continues from previous
+    $u.query.hash-format = URI::Query::Singles;
+
+    # These are never lists now
+    say $u.query<foo>; #> 3
+    say $u.query<bar>; #> 2
+
+The `URI::Query::Lists` mode is default and recommended mode.
+
+GRAMMAR
+-------
+
+This class will keep a copy of the result of parsing the URI string for you. If you are interested in precise details of the parse tree, you get them using the `grammar` method:
+
+    my $host-in-grammar =
+        $u.grammar.parse-result<URI-reference><URI><hier-part><authority><host>;
+    if $host-in-grammar<reg-name> {
+        say 'Host looks like registered domain name - approved!';
+    }
+    else {
+        say 'Sorry we do not take ip address hosts at this time.';
+        say 'Please use registered domain name!';
+    }
+
+The `IETF::RFC_Grammar::URI` grammar sticks close to the BNF defined in RFC 3986.
+
+PARTIAL MATCHING
+----------------
+
+Many times a URI you are interested in is embedded within another string. This class will allow you to parse URIs out of a larger string, so long as the URI is at the start. This is done by setting the `:match-prefix` option during construction or when calling `parse`:
+
+    {
+        # require whole string matches URI and throw exception otherwise ..
+        my $u_v = URI.new('http://?#?#');
+        CATCH { when X::URI::Invalid { ... } }
+    }
+
+    my $u_pfx = URI.new('http://example.com } function(var mm){', :match-prefix);
+
+METHODS
+=======
+
+method new
+----------
+
+    multi method new(URI:U: Str() $uri, Bool :$match-prefix) returns URI:D
+    multi method new(URI:U: Str() :$uri, Bool :$match-prefix) returns URI:D
+
+These construct a new `URI` object and return it. The given `$uri` value is converted to a string and then parsed using the `parse` method.
+
+If `:match-prefix` is set, then the grammar will be allowed to match a prefix of the given input string rather than requiring a total match. The `:match-prefix` given also becomes the default value for any figure calls to `parse`.
+
+Throws a `X::URI::Invalid` exception if the URI cannot be parsed.
+
+method parse
+------------
+
+    method parse(URI:D: Str() $str, Bool :$match-prefix = $.match-prefix)
+
+This method allows an existing URI object to be reused to parse another string. This parses the given string and replaces all internal state of the object with values for the new parse.
+
+The given `:match-prefix` flag becomes the new default when set.
+
+Throws a `X::URI::Invalid` exception if the URI cannot be parsed.
+
+method grammar
+--------------
+
+    method grammar(URI:D:) returns IETF::RFC_Grammar:D
+
+Returns the object used to parse and store the state of the parse.
+
+method match-prefix
+-------------------
+
+    method match-prefix(URI:D:) returns Bool:D
+
+Returns True if the most recent call to `parse` (or `new`) allowed a prefix match or False if a total match was required. This is the default value of any future call to `parse`.
+
+method scheme
+-------------
+
+    multi method scheme(URI:D:) returns URI::Scheme:D
+    multi method scheme(URI:D: Str() $scheme) returns URI::Scheme:D
+
+Returns the scheme part of the URI. This is a string that must match the `URI::Scheme` subset type.
+
+The second form allows the scheme to be replaced with a new scheme. It is legal for the scheme to be set to an empty string, which has the effect of making the URI scheme-less.
+
+This will throw an `X::URI::Path::Invalid` exception if adding or removing the scheme will make the URI invalid. See SCHEME, AUTHORITY, AND PATH section for additional details.
+
+method authority
+----------------
+
+    multi method authority(URI:D:) returns URI::Authority
+    multi method authority(URI:D: Nil) returns URI::Authority:U
+    multi method authority(URI:D: Str() $new) returns URI::Authority:D
+
+Returns the `URI::Authority` for the current URI object. This may be an undefined type object if no authority has been set or found during parse.
+
+When passed a string, the string will have the authority parsed out of it and a new authority object will be used to store the parsed information. An empty authority is valid.
+
+When passed `Nil`, the authority will be cleared.
+
+When passing an argument, this will throw an `X::URI::Path::Invalid` exception if setting or clearing the authority on the URI will make the URI invalid. See SCHEME, AUTHORITY, AND PATH section for details.
+
+The authority is made up of three components: userinfo, host, and port. Additional methods are provided for accessing each of those parts separately.
+
+method userinfo
+---------------
+
+    multi method userinfo(URI:D:) returns URI::Userinfo:D
+    multi method userinfo(URI:D: Str() $new) returns URI::Userinfo:D
+
+The userinfo is an optional component of the URI authority. This method returns the current userinfo or an empty string.
+
+Setting this method will cause a `URI::Authority` to be constructed and `authority` to be set, if it is not already defined. This may result in a `X::URI::Path::Invalid` exception being thrown if adding an authority will make the path invalid.
+
+method host
+-----------
+
+    multi method host(URI:D:) returns URI::Host:D
+    multi method host(URI:D: Str() $new) returns URI::Host:D
+
+The host is a component of the URI authority. This method returns the current host or an empty string.
+
+Setting this method will cause a `URI::Authority` to be constructed and `authority` to be set, if it is not already defined. This may result in a `X::URI::Path::Invalid` exception being thrown if adding an authority will make the path invalid.
+
+method default-port
+-------------------
+
+    method default-port(URI:D:) returns URI::Port
+
+This method applies the `scheme-port` method of `URI::DefaultPort` to the scheme set on this object. Basically, a shortcut for:
+
+    my $u = URI.new("...");
+    my $port = URI::DefaultPort.scheme-port($u.scheme);
+
+It returns the usual port for the named scheme.
+
+method _port
+------------
+
+    multi method _port(URI:D:) returns URI::Port
+    multi method _port(URI:D: Nil) returns URI::Port:U
+    multi method _port(URI:D: Int() $new) returns URI::Port:D
+
+When an authority is set on the URI, this gets or sets the authority's port. This differs from `port`, which returns either the port set or the `default-port`. This method returns just the port.
+
+If no authority is set or no port is set, this returns an undefined value (i.e., an `Int` type object).
+
+Setting this method will cause a `URI::Authority` to be constructed and `authority` to be set, if it is not already defined. This may result in a `X::URI::Path::Invalid` exception being thrown if adding an authority will make the path invalid.
+
+method port
+-----------
+
+    multi method port(URI:D:) returns URI::Port
+    multi method port(URI:D: Nil) returns URI::Port
+    multi method port(URI:D: Int() $new) returns URI::Port
+
+When retrieving a value from the object, this method returns either the port set on the authority or the default port for the current URI scheme. It may return an undefined value (i.e., an `Int` type object) if there is no port set and no known default port for the current scheme or no scheme set.
+
+When setting a value on the object, this method sets the port on the authority.
+
+Setting this method will cause a `URI::Authority` to be constructed and `authority` to be set, if it is not already defined. This may result in a `X::URI::Path::Invalid` exception being thrown if adding an authority will make the path invalid.
+
+method path
+-----------
+
+    multi method path(URI:D:) returns URI::Path:D
+    multi method path(URI:D: Str() $path) returns URI::Path:D
+
+Path is the main required element of a URI, but may be an empty string. This method returns the current setting for the path as a `URI::Path` object. It also allows setting a new path, which will construct a new `URI::Path` object.
+
+This method will throw a `X::URI::Path::Invalid` exception if the path is not valid for the current scheme and authority settings.
+
+method segments
+---------------
+
+    multi method segments(URI:D:) returns List:D
+    multi method segments(URI:D: @segments where *.elems > 0) returns List:D
+    multi method segments(URI:D: $first-segment, *@remaining-segments) returns List:D
+
+Returns the path segments (i.e., the parts between slashes). This is a shortcut for:
+
+    my $u = URI.new("...");
+    my @s = $u.path.segments;
+
+The number of segments is equal to the number of slashes in the original path plus one. The segments are constructed so that joining the segments by a slash (/) will give you the original path.
+
+You may pass a list in to replace the segments with a new value. This will throw a `X::URI::Path::Invalid` exception if any of the segments contain a slash or if the set path will cause the URI to become invalid.
+
+Be sure when setting segments to include an initial empty string if you want the path to start with a slash.
+
+method query
+------------
+
+    multi method query(URI:D:) returns URI::Query:D
+    multi method query(URI:D: Str() $new) returns URI::Query:D
+    multi method query(URI:D: *@new) returns URI::Query:D
+
+Accesses or updates the query associated with the URI. This is returns as a `URI::Query` object. This will always be defined, but may be empty.
+
+When passed a string, the string will be parsed using `split-query` and the query object will be updated. When passed a list, the list of `Pair`s given will be used to setup a new query that way.
+
+When the list form is used, any named parameters passed will be ignored (they will not be used to fill the query) and a warning will be issued.
+
+method path-query
+-----------------
+
+    method path-query(URI:D:) returns Str:D
+
+Returns the path and query as a string joined by a question mark ("?"). It will return just the path as a string if the query is empty.
+
+method fragment
+---------------
+
+    multi method fragment(URI:D:) returns URI::Fragment:D
+    multi method fragment(URI:D: Str() $new) returns URI::Fragment:D
+
+Returns the URI fragment, which is always defined, but may be an empty string. If passed a value, it will set the fragment.
+
+method gist
+-----------
+
+    multi method gist(URI:D:) returns Str:D
+
+Reconstructs the URI from the components and returns it as a string.
+
+method Str
+----------
+
+    multi method Str(URI:D:) returns Str:D
+
+Reconstructs the URI from the components and returns it as a string.
+
+SUBROUTINES
+===========
+
+sub split-query
+---------------
+
+    sub split-query(Str() $query, :$hash-format = URI::Query::None)
+
+This routine will slice and dice a query string, which is useful when parsing URIs and may also be useful when parsing POST entities that are encoded as `application/x-www-form-urlencoded`.
+
+This routine is exported with the `:split-query` tag or can be used with the full namespace, `URI::split-query`.
+
+With just the required string, this routine will parse that string and return a list of `Pair`s mapping each query form key to its respective value. The order is preserved. This is used by `URI::Query` during construction.
+
+For example:
+
+    my @qf = URI::split-query("foo=1&bar%20=2&foo=3");
+    dd @qf; #> Array @qf = [:foo("1"), "bar " => ("2"), :foo("3")]
+
+Notice that this will perform a `uri-escape` operation of keys and values in the process so the values you receive have had the URI encoded characters decoded.
+
+You can retrieve the query string as a hash instead by passing the `:hash-format` option. This works exactly as it does for `URI::Query`.
+
+The options for `:hash-format` include:
+
+### URI::Query::Lists
+
+Every key is mapped to a list of one or more values. From the example input, a structure like the following is returned:
+
+    my %qf = URI::split-query("foo=1&bar%20=2&foo=3",
+        hash-format => URI::Query::Lists,
+    );
+    dd %qf; #> Hash %qf = {"bar " => (["2"]), :foo(["1", "3"])}
+
+This is also the default if you just pass `:hash-format` as a boolean option.
+
+### URI::Query::Mixed
+
+Every key is mapped to either a list of two or more values or directly to a single value, like the following:
+
+    my %qf = URI::split-query("foo=1&bar%20=2&foo=3",
+        hash-format => URI::Query::Mixed,
+    );
+    dd %qf; #> Hash %qf = {"bar " => ("2"), :foo(["1", "3"])}
+
+### URI::Query::Singles
+
+Every key is mapped to a single value, which will be the last value encountered in the input, like this:
+
+    my %qf = URI::split-query("foo=1&bar%20=2&foo=3",
+        hash-format => URI::Query::Mixed,
+    );
+    dd %qf; #> Hash %qf = {"bar " => ("2"), :foo("3")}
+
+HELPER SUBSETS
+==============
+
+URI::Scheme
+-----------
+
+This is a subset of `Str` that only accepts valid schemes.
+
+URI::Userinfo
+-------------
+
+This is a subset of `Str` that only accepts valid userinfo.
+
+URI::Host
+---------
+
+This is a subset of `Str` that only accepts valid hosts.
+
+URI::Port
+---------
+
+This is a subset of `UInt`.
+
+URI::Query::ValidQuery
+----------------------
+
+This is a subset of `Str` that only accepts valid query strings.
+
+URI::Fragment
+-------------
+
+This is a subset of `Str` that only accepts valid URI fragments.
+
+HELPER CLASSES
+==============
+
+URI::Authority
+--------------
+
+The `authority` method of a URI constructs or returns this object.
+
+It is recommended that you do not costruct a `URI::Authority` object directly, but let the methods of `URI` handle construction.
+
+### method userinfo
+
+    method userinfo(URI::Authority:D:) is rw returns URI::Userinfo:D
+
+This is a simple setter/getter for the userinfo on the authority. It must be defined, but may be the empty string. If not empty, it must be valid for the userinfo component of a URI.
+
+### method host
+
+    method host(URI::Authority:D:) is rw returns URI::Host:D
+
+This is a simple setter/getter for the host part of the URI authority. It must be defined, but may be the empty string. If not empty, must be a valid host value, which may be an IP address or registered name.
+
+### method port
+
+    method port(URI::Authority:D:) is rw returns URI::Port
+
+This is a simple setter/getter for the port part of the URI authority. It may be set to an undefined value if no explicit port is set in the authority. If defined, it must an unsigned integer.
+
+### method gist
+
+    multi method gist(URI::Authority:D:) returns Str:D
+
+Returns the string representation of the URI authority. For example,
+
+    my $u = URI.new("http://steve@example.com:8008");
+
+    # say calls .gist
+    say $u.authority; #> "steve@example.com:8080";
+
+### method Str
+
+    multi method gist(URI::Authority:D:) returns Str:D
+
+Stringifies identical to `gist`.
+
+URI::Path
+---------
+
+This class is used to represent URI path components.
+
+It is recommended that you do not construct a `URI::Path` object directly, but rely on the `path` setter in `URI` instead. These objects are immutable. Please use methods on `URI` to make changes.
+
+### method path
+
+    method path(URI::Path:D:) returns Str:D
+
+Returns the string representation of the path.
+
+### method segments
+
+    method segments(URI::Path:D:) returns List:D
+
+Returns a list representation of the path segments. In a URI, the path segments are the strings between slashes ("/").
+
+### method gist
+
+    method gist(URI::Path:D:) returns Str:D
+
+Returns the `path`.
+
+### method Str
+
+    method Str(URI::Path:D:) returns Str:D
+
+Returns the `path`.
+
+URI::Query
+----------
+
+This class is used to represent a URI query component. This class may be safely constructed and used independently of the URI object.
+
+It behaves as both a positional and associative object and is iterable. Internally, it is stored as an `Array` of `Pair`s. You must not treat this object purely as you would an `Array` or purely as you would a `Hash` as some methods will not work the way you expect.
+
+The performance of the associative methods is not guaranteed and is probably going to be relatively slow. This implementation values simplicity and accuracy of representation to CPU performance. If you need something that is better for CPU performance, you should investigate the use of another library, such as `Hash::MultiValue` or sub-class to provide a higher performance implementation of `URI::Query`'s associative methods.
+
+### method new
+
+    multi method new(Str() $query, URI::Query::HashFormat :$hash-format = URI::Query::Lists) returns URI::Query:D
+    multi method new(:$query, URI::Query::HashFormat :$hash-format = URI::Query::Lists) returns URI::Query:D
+
+Constructs a new `URI::Query` from the given string, which may be empty.
+
+Unlike `split-query`, which permits boolean values for the `hash-format` option, `URI::Query` requires a `URI::Query::HashFormat` value and will reject a boolean (because the boolean does not make sense in this case).
+
+### enum HashFormat
+
+This enumeration provides the values that may be set on `hash-format` on a `URI::Query`. Possible values are as follows.
+
+#### URI::Query::List
+
+This is the default and recommended value. When set in `hash-format`, each key in the hash representation will point to a list of one or more values.
+
+This is recommended as it is the most accurate representation to what is actually possible in a query string. The values within each key will be sorted in the same order as they appear in the query.
+
+#### URI::Query::Mixed
+
+When set in `hash-format`, each key in the hash representation may be mapped to either a list of two or more values, or to the value itself if there is only one.
+
+This is not recommended because it means that setting a key to an iterable value will be treated as multiple key-value pairs when it comes time to render the query as a string. This could have unintended consequences.
+
+#### URI::Query::Singles
+
+When set in `hash-format`, each key in the hash representation will be mapped directly to a single value. If there are multiple values that have been set in the query, then only the last will be visible through the hash representation.
+
+This is not recommended because it may hide certain values, but may be useful for simple applications that treat the query string as having unique values. Just note that the trade-off is that your application may be confused when multiple values are present.
+
+#### URI::Query::None
+
+This value should not be used, but will be treated the same as `URI::Query::List` if used here. It is provided for use with `split-query` only.
+
+### method hash-format
+
+    method hash-format(URI::Query:D) is rw returns URI::Query::HashFormat
+
+This is a simple setter/getter for setting the way in which associative lookups are performed. See `enum URI::Query::HashFormat` for a description of each mode.
+
+### method query
+
+    method query(Query:D:) returns URI::Query::ValidQuery:D
+    method query(Query:D: Str() $new) returns URI::Query::ValidQuery:D
+
+This method returns the string representation of the URI query component. When passed a string, it will replace the query with the new value and will use `split-query` to parse that query into an array of `Pair`s.
+
+The primary representation of the queryo object is the value returned by `query-form`. The `query` is cached to keep the value stored in it when this method is called to set it or when `URI::Query` is constructed from a string. Any modification to the internal array of pairs, though, will clear this cache. It will be generated the next time the `query` method is called and that string will be cached.
+
+### method query-form
+
+    method query-form(Query:D:) returns Array:D
+    method query-form(Query:D: *@new, *%new) returns Array:D
+
+This method returns the array of `Pair`s that store the internal representation of the URI query component. When passed an array of `Pair`s, it will replace the current value with that array.
+
+A quick note about the way pairs are passed as parameters to a method, you most likely want to avoid passing values as named parameters. If values are passed using unquoted strings, they will be treated as named parameters, which is most likely what you want:
+
+    my $q = URI::Query.new;
+
+    # Prefer this
+    $q.query-form('foo' => 1, 'bar' => 2, 'foo' => 3);
+
+    # Avoid these
+    $q.query-form(foo => 1, bar => 2, foo => 3);
+    $q.query-form(:foo(1), :bar(2), :foo(3));
+
+The latter two will result in the first "foo" pair being lost. Named parameters assume unique names and the latter "foo" key will effectively override the former.
+
+That said, the method will allow hashes to be passed in, if that is your preference.
+
+### method of
+
+    method of()
+
+Always returns `Pair`.
+
+### method iterator
+
+    method iterator(Query:D:) returns Iterator:D
+
+Returns the iterator on the internal array of `Pair`s.
+
+### method postcircumflex:<[ ]>
+
+    method postcircumflex:<[ ]> returns Pair
+
+This permits positional access to each `Pair` stored internally. You may use this to get a `Pair`, set a `Pair`, test for existence, or delete.
+
+### method postcircumflex:<{ }>
+
+    method postcircumflex:<{ }>
+
+This permits associative access to the values stored internally by key. What is returned here when fetching values depends on the setting in `hash-format`, a list of one or more values or `Nil`, by default. You can use this for getting, setting, existence testing, or deletion.
+
+### method keys
+
+    method keys(Query:D:) returns Seq:D
+
+This method returns all the keys of the query in order.
+
+### method values
+
+    method values(Query:D:) returns Seq:D
+
+This method returns all the values of the query in order.
+
+### method kv
+
+    method kv(Query:D:) returns Seq:D
+
+This method returns a sequence alternating the keys and values of the query in order.
+
+### method pairs
+
+    method kv(Query:D:) returns Seq:D
+
+This method returns a copy of the internal representation of the query string array.
+
+### method pop
+
+    method pop(Query:D:) returns Pair
+
+This method removes the last Pair from the array of pairs and returns it.
+
+### method push
+
+    method push(Query:D: *@new)
+
+This method adds the given pairs to the end of the array of pairs in the query using push semantics.
+
+### method append
+
+    method append(Query:D: *@new)
+
+This method adds the given pairs to the end of the array of pairs in the query using append semantics.
+
+### method shift
+
+    method shift(Query:D:) returns Pair
+
+This method removes the first Pair from the array of pairs and returns it.
+
+### method unshift
+
+    method unshift(Query:D: *@new)
+
+This method adds the given pairs to the front of the array of pairs in the query using unshift semantics.
+
+### method prepend
+
+    method prepend(Query:D: *@new)
+
+This method adds the given pairs to the front of the array of pairs in the query using prepend semantics.
+
+### method splice
+
+    method splice(Query:D: $start, $elems?, *@replacement)
+
+This method removes a `$elems` number of pairs from the array of pairs in the query starting at index `$start`. It then inserts the pairs in `@replacement` into that part of the array (if any are given).
+
+### method elems
+
+    method elems(Query:D:) returns Int:D
+
+Returns the number of pairs stored in the query.
+
+### method end
+
+    method end(Query:D:) returns Int:D
+
+Returns the index of the last pair stored in the query.
+
+### method Bool
+
+    method Bool(Query:D:) returns Bool:D
+
+Returns `True` if the at least one pair is stored in the query or `False` otherwise.
+
+### method Int
+
+    method Int(Query:D:) returns Int:D
+
+Returns `elems`.
+
+### method Numeric
+
+    method Numeric(Query:D:) returns Int:D
+
+Returns `elems`.
+
+### method gist
+
+    method gist(Query:D:) returns Str:D
+
+Returns the `query`.
+
+### method Str
+
+    method Str(Query:D:) returns Str:D
+
+Returns the `query`.
+
+EXCEPTIONS
+==========
+
+X::URI::Invalid
+---------------
+
+This exception is thrown in many places where the URI is being parsed or manipulated. If the string being parsed is not a valid URI or if certain manipulations of the URI object would cause it to become an invalid URI, this exception may be used.
+
+It provides a `source` accessor, which returns the string that was determined to be invalid.
+
+X::URI::Path::Invalid
+---------------------
+
+In some cases where an attempt is made to set `path` to an invalid value, this exception is thrown.
+
+The `source` field will name the invalid URI. Strictly speaking, the URI might be valid, but will not parse the same way as given. To make it clear that this is the case, the `path` field names the invalid path part.
+
+In cases where the segments have been modified in an invalid way, the first invalid segment will be set in `bad-segment`.
+
+AUTHORS
+=======
+
+Contributors to this module include:
+
+  * Ronald Schmidt (ronaldxs)
+
+  * Moritz Lentz (moritz)
+
+  * Nick Logan (ugexe)
+
+  * Tobias Leich (FROGGS)
+
+  * Jonathan Stowe (jonathanstowe)
+
+  * Justin DeVuyst (jdv)
+
+  * Solomon Foster (colomon)
+
+  * Roman Baumer (rba)
+
+  * Zoffix Znet (zoffixznet)
+
+  * Ahmad M. Zawawi (azawawi)
+
+  * Gabor Szabo (szabgab)
+
+  * Samantha McVey (samcv)
+
+  * Pawel Pabian (bbkr)
+
+  * Rob Hoelz (hoelzro)
+
+  * radiak
+
+  * Paul Cochrane (paultcochrane)
+
+  * Steve Mynott (stmuk)
+
+  * timo
+
+  * David Warring (dwarring)
+
+  * Sterling Hanenkamp (zostay)
+
+COPYRIGHT & LICENSE
+===================
+
+Copyright 2017 Ronald Schmidt.
+
+This software is licensed under the same license as Perl 6 itself.

--- a/lib/IETF/RFC_Grammar.pm
+++ b/lib/IETF/RFC_Grammar.pm
@@ -16,16 +16,15 @@ use IETF::RFC_Grammar::URI;
 
 has $.rfc;
 has $.grammar;
-has $.parse_result;
+has $.parse-result;
 
 method parse($parse_str, :$rule = 'TOP') {
-    $!parse_result = $!grammar.parse($parse_str, :$rule);
+    $!parse-result = $!grammar.parse($parse_str, :$rule);
 }
 
 method subparse($parse_str, :$rule = 'TOP') {
-    $!parse_result = $!grammar.subparse($parse_str, :$rule);
+    $!parse-result = $!grammar.subparse($parse_str, :$rule);
 }
-
 
 submethod BUILD(:$!rfc, :$!grammar) {}
 
@@ -51,3 +50,4 @@ method new(Str $rfc, $grammar?) {
    return self.bless(:$rfc, :grammar($init_grammar));
 }
 
+method parse_result { $!parse-result }

--- a/lib/IETF/RFC_Grammar.pm
+++ b/lib/IETF/RFC_Grammar.pm
@@ -18,12 +18,12 @@ has $.rfc;
 has $.grammar;
 has $.parse_result;
 
-method parse($parse_str) {
-    $!parse_result = $!grammar.parse($parse_str);
+method parse($parse_str, :$rule = 'TOP') {
+    $!parse_result = $!grammar.parse($parse_str, :$rule);
 }
 
-method subparse($parse_str) {
-    $!parse_result = $!grammar.subparse($parse_str);
+method subparse($parse_str, :$rule = 'TOP') {
+    $!parse_result = $!grammar.subparse($parse_str, :$rule);
 }
 
 
@@ -48,6 +48,6 @@ method new(Str $rfc, $grammar?) {
         die "Need either rfc with known grammar or grammar";
     }
 
-   return self.bless(rfc => $rfc, grammar => $init_grammar);
+   return self.bless(:$rfc, :grammar($init_grammar));
 }
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -53,7 +53,6 @@ has Str $.query-form-delimiter;
 has $.grammar;
 has Bool $.match-prefix = False;
 has Path $.path = '';
-has $!is_absolute;  # part of deprecated code scheduled for removal
 has Scheme $.scheme is rw = '';
 has Userinfo $.userinfo is rw = '';
 has Host $.host = '';
@@ -77,7 +76,7 @@ method parse (Str $str, :$match-prefix) {
     $!path     = '';
     $!query    = '';
     $!fragment = '';
-    $!uri = $!is_absolute = Mu;
+    $!uri = Mu;
     %!query-form := Map.new();
     @!segments := ();
 
@@ -244,7 +243,6 @@ my regex relative-ref-paths {
 method !make-path($comp_container) {
     my $path = $comp_container<path-abempty>       ||
                $comp_container<path-absolute>      ;
-    $!is_absolute = ?($path || $!scheme); # part of deprecated code
 
     $path ||=  $comp_container<path-noscheme>      ||
                $comp_container<path-rootless>      ;

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -46,6 +46,9 @@ our subset Path of Str
 our subset Query of Str
     where /^ <IETF::RFC_Grammar::URI::query> $/;
 
+our subset Fragment of Str
+    where /^ <IETF::RFC_Grammar::URI::fragment> $/;
+
 has Str $.query-form-delimiter;
 has $.grammar;
 has Bool $.match-prefix = False;
@@ -56,8 +59,8 @@ has Userinfo $.userinfo is rw = '';
 has Host $.host = '';
 has Port $._port is rw;
 has Query $.query = '';
-has $!frag;
-has %!query-form;
+has Fragment $.fragment is rw = '';
+has %!query-form; # cache query-form
 has $!uri;  # use of this now deprecated
 
 has @.segments;
@@ -69,11 +72,12 @@ method parse (Str $str, :$match-prefix) {
     $c_str .= subst(/^ \s* ['<' | '"'] /, '');
     $c_str .= subst(/ ['>' | '"'] \s* $/, '');
 
-    $!scheme = '';
-    $!_port  = Nil;
-    $!path   = '';
-    $!query  = '';
-    $!uri = $!is_absolute = $!frag = Mu;
+    $!scheme   = '';
+    $!_port    = Nil;
+    $!path     = '';
+    $!query    = '';
+    $!fragment = '';
+    $!uri = $!is_absolute = Mu;
     %!query-form := Map.new();
     @!segments := ();
 
@@ -97,7 +101,7 @@ method parse (Str $str, :$match-prefix) {
 
     $!scheme = .lc with $comp_container<scheme>;
     $!query = .Str with $comp_container<query>;
-    $!frag = $comp_container<fragment>;
+    $!fragment = .lc with $comp_container<fragment>;
     $comp_container = $comp_container<hier-part> || $comp_container<relative-part>;
 
     my $authority = $comp_container<authority>;
@@ -310,25 +314,21 @@ method path-query {
 
 method path_query { $.path-query } #artifact form
 
-method frag {
-    return ($!frag // '').lc;
-}
-
-method fragment { $.frag }
+method frag { $.fragment }
 
 method !gister(
     :$scheme = $.scheme,
     :$authority = $.authority,
     :$path = $.path,
     :$query = $.query,
-    :$frag = $.frag,
+    :$fragment = $.fragment,
 ) {
     my Str $s;
     $s ~= $scheme if $scheme;
     $s ~= '://' ~ $authority if $authority;
     $s ~= $path;
     $s ~= '?' ~ $query if $query;
-    $s ~= '#' ~ $frag if $frag;
+    $s ~= '#' ~ $fragment if $fragment;
     $s;
 }
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -31,17 +31,8 @@ class X::URI::Authority::Invalid is X::URI::Invalid {
 
 class Authority {
     has Userinfo:D $.userinfo is default('') is rw = '';
-    has Host:D $.host is required is rw where *.chars > 0;
+    has Host:D $.host is default('') is rw = '';
     has Port $.port is rw;
-
-    multi method new(Authority:U: IETF::RFC_Grammar:D $grammar, Str:D $authority) {
-        $grammar.parse($authority, rule => 'authority');
-        if not $grammar.parse_result {
-            X::URI::Authority::Invalid.new(source => $authority).throw;
-        }
-
-        self.new($grammar.parse_result);
-    }
 
     multi method new(Authority:U: Match:D $auth) {
         my Str $userinfo = do with $auth<userinfo> { .Str } else { '' }
@@ -94,7 +85,7 @@ class Path {
         self.new(:$path, :@segments);
     }
 
-    submethod BUILD(:$!path = '', :@segments) {
+    submethod BUILD(:$!path = '', :@segments = ('',)) {
         @!segments := @segments.List;
     }
 
@@ -277,15 +268,15 @@ method parse(URI:D: Str() $str, Bool :$match-prefix = $!match-prefix) {
     }
 
     # hacky but for the time being an improvement
-    if (not $!grammar.parse_result) {
+    if (not $!grammar.parse-result) {
         X::URI::Invalid.new(source => $str).throw
     }
 
     # now deprecated
-    $!uri = $!grammar.parse_result;
+    $!uri = $!grammar.parse-result;
 
-    my $comp_container = $!grammar.parse_result<URI-reference><URI> ||
-        $!grammar.parse_result<URI-reference><relative-ref>;
+    my $comp_container = $!grammar.parse-result<URI-reference><URI> ||
+        $!grammar.parse-result<URI-reference><relative-ref>;
 
     $!scheme = .lc with $comp_container<scheme>;
     $!query.query(.Str) with $comp_container<query>;
@@ -439,15 +430,14 @@ multi method userinfo(URI:D:) returns Userinfo {
     '';
 }
 
-multi method userinfo(URI:D: Str() $new) returns Userinfo {
+multi method userinfo(URI:D: Str() $userinfo) returns Userinfo {
     with $!authority {
-        .userinfo = $new;
+        .userinfo = $userinfo;
     }
-    elsif $new ne '' {
-        X::URI::Authority::Invalid.new(
-            before => 'userinfo',
-            source => "$new@",
-        ).throw
+    elsif $userinfo {
+        self!check-path(:has-authority, :source(self!gister(:authority("$userinfo@"))));
+        $!authority .= new(:$userinfo);
+        $!authority.userinfo;
     }
 }
 
@@ -456,29 +446,15 @@ multi method host(URI:D:) returns Host {
     '';
 }
 
-multi method host(URI:D: Str() $new) returns Host {
+multi method host(URI:D: Str() $host) returns Host {
     with $!authority {
-        if $new eq '' {
-            self!check-path(:!has-authority,
-                source => self!gister(authority => ''),
-            );
-
-            $!authority = Nil;
-        }
-        else {
-            .host = $new;
-        }
+        .host = $host;
     }
-    elsif $new ne '' {
-        self!check-path(:has-authority,
-            source => self!gister(authority => $new),
-        );
-
-        $!authority .= new(host => $new, userinfo => '');
+    elsif $host {
+        self!check-path(:has-authority, :source(self!gister(:authority($host))));
+        $!authority .= new(:$host);
         $!authority.host;
     }
-
-    $new;
 }
 
 method default-port(URI:D:) returns Port {
@@ -496,15 +472,14 @@ multi method _port(URI:D: Nil) returns Port {
     Nil;
 }
 
-multi method _port(URI:D: Int() $new) returns Port {
+multi method _port(URI:D: Int() $port) returns Port {
     with $!authority {
-        .port = $new;
+        .port = $port;
     }
     else {
-        X::URI::Authority::Invalid.new(
-            before => 'port',
-            source => ":$new",
-        ).throw
+        self!check-path(:has-authority, :source(self!gister(:authority(":$port"))));
+        $!authority .= new(:$port);
+        $!authority.port;
     }
 }
 
@@ -517,35 +492,48 @@ multi method authority(URI:D:) returns Authority {
     $!authority;
 }
 
-multi method authority(URI:D: Str() $authority) returns Authority {
-    if $authority ne '' {
-        without $!authority {
-            self!check-path(:has-authority,
-                source => self!gister(authority => $authority),
-            );
-        }
-
-        $!authority = Authority.new($!grammar, $authority);
+multi method authority(URI:D: Str() $authority) returns Authority:D {
+    my $gist;
+    without $!authority {
+        self!check-path(:has-authority,
+            source => $gist //= self!gister(:$authority),
+        );
     }
-    else {
-        with $!authority {
-            self!check-path(:!has-authority,
-                source => self!gister(authority => $authority),
-            );
-        }
 
-        $!authority = Nil;
+    $!grammar.parse($authority, rule => 'authority');
+    if not $!grammar.parse-result {
+        X::URI::Invalid.new(
+            source => $gist // self!gister(:$authority),
+        ).throw;
     }
+
+    $!authority = Authority.new($!grammar.parse-result);
+}
+
+multi method authority(URI:D: Nil) returns Authority:U {
+    with $!authority {
+        self!check-path(:!has-authority,
+            source => self!gister(authority => ''),
+        );
+    }
+
+    $!authority = Nil;
 }
 
 multi method path(URI:D:) returns Path:D { $!path }
 
 multi method path(URI:D: Str() $path) returns Path:D {
-    my $comp = self!check-path(:$path,
-        source => self!gister(path => $path),
-    );
+    if $path {
+        my $comp = self!check-path(:$path,
+            source => self!gister(:$path),
+        );
 
-    $!path = Path.new($comp);
+
+        $!path = Path.new($comp);
+    }
+    else {
+        $!path = Path.new;
+    }
 }
 
 multi method segments(URI:D:) returns List:D { $!path.segments }
@@ -635,7 +623,7 @@ method chunks {
 }
 
 method uri {
-    warn "uri attribute now deprecated in favor of .grammar.parse_result";
+    warn "uri attribute now deprecated in favor of .grammar.parse-result";
     $!uri;
 }
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -424,6 +424,7 @@ method default_port { $.default-port() } # artifact form
 
 multi method _port(URI:D:) returns Port {
     return-rw .port with $!authority;
+    return Nil;
 }
 
 multi method port(URI:D:) returns Port { $._port // $.default-port }

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -116,7 +116,7 @@ class Query does Positional does Associative does Iterable {
         self.new(:$query);
     }
 
-    submethod BUILD(:$!query, :@!query-form, :$!hash-format = Lists) {
+    submethod BUILD(:$!query = '', :@!query-form, :$!hash-format = Lists) {
         die "When calling URI::Query.new set either :query or :query-form, but not both."
             if @!query-form and $!query;
 
@@ -182,9 +182,9 @@ class Query does Positional does Associative does Iterable {
     }
 
     # Hash-like readers
-    method keys(Query:D:) { @!query-form».key }
-    method values(Query:D:) { @!query-form».value }
-    method kv(Query:D:) { @!query-form».kv.flat }
+    method keys(Query:D:) { @!query-form.map(*.key) }
+    method values(Query:D:) { @!query-form.map(*.value) }
+    method kv(Query:D:) { @!query-form.map(*.kv).flat }
     method pairs(Query:D:) { @!query-form }
 
     # Array-like manipulators
@@ -225,7 +225,7 @@ class Query does Positional does Associative does Iterable {
 
     multi method query(Query:D: Str() $new) {
         $!query = $new;
-        @!query-form = split-query($!query) if $!query;
+        @!query-form = split-query($!query);
         $!query;
     }
 
@@ -312,7 +312,7 @@ our sub split-query(
         }
 
         # or if the component contains just abc
-        default {
+        when /./ {
             take $_ => True;
         }
     }

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -112,8 +112,8 @@ class Query does Positional does Associative does Iterable {
     has ValidQuery $!query;
     has Pair @!query-form;
 
-    multi method new(Str() $query) {
-        self.new(:$query);
+    multi method new(Str() $query, :$hash-format = Lists) {
+        self.new(:$query, :$hash-format);
     }
 
     submethod BUILD(:$!query = '', :@!query-form, :$!hash-format = Lists) {

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -10,6 +10,15 @@ class X::URI::Invalid is Exception {
     method message { "Could not parse URI: $!source" }
 }
 
+class X::URI::Path::Invalid is X::URI::Invalid {
+    has $.path;
+    has $.bad-segment;
+    method message {
+        qq[Could not parse path "$!path" as part of URI: $.source]
+        ~ ($!bad-segment ?? qq[ with bad segment "$!bad-segment"] !! '')
+    }
+}
+
 our subset Scheme of Str
     where /^ [
            ''
@@ -20,14 +29,6 @@ our subset Userinfo of Str
 our subset Host of Str
     where /^ [ <IETF::RFC_Grammar::URI::host> ] $/;
 our subset Port of UInt;
-
-class X::URI::Authority::Invalid is X::URI::Invalid {
-    has $.before;
-    method message {
-        "Could not parse URI authority ($.source)."
-        ~ $!before ?? " Did you forget to set .host before .$!before?" !! ''
-    }
-}
 
 class Authority {
     has Userinfo:D $.userinfo is default('') is rw = '';
@@ -54,8 +55,10 @@ class Authority {
 }
 
 # Because Path is limited in form based on factors outside of it, it doesn't
-# actually provide any validation within itself. This type is immutable. The URI
-# class is responsible for performing the necessary validations.
+# actually provide any validation within itself. As such, this type is immutable
+# to prevent a problem. This could be made mutable if it is given a reference to
+# the parent URI class. The URI class is responsible for performing the
+# necessary validations.
 class Path {
     has Str $.path;
     has @.segments;
@@ -72,12 +75,13 @@ class Path {
         my $path-type = @rules.first({ $comp{ $_ }.defined });
         my $path = $comp{ $path-type };
 
-        my @segments := $path<segment>.list.map({.Str}).List || ('',);
-        if my $first_chunk = $path<segment-nz-nc> || $path<segment-nz> {
-            @segments := ($first_chunk.Str, |@segments);
+        my @segments := $path<segment>.list.map({.Str}).List || ('', );
+        if $path<segment-nz-nc> || $path<segment-nz> -> $first-chunk {
+            @segments := ($first-chunk.Str, |@segments);
         }
-        if @segments.elems == 0 {
-            @segments := ('',);
+
+        if "$path".starts-with('/') {
+            @segments := ('', |@segments);
         }
 
         $path = "$path";
@@ -403,7 +407,7 @@ method !check-path(
     :$path          = $.path,
     :$source        = $.gist,
 ) {
-    with X::URI::Invalid.new(:$source) -> \ex {
+    given X::URI::Path::Invalid.new(:$path, :$source) -> \ex {
         if $has-authority {
             ex.throw unless $path ~~ /^ <path-authority> $/;
             return $<path-authority>;
@@ -537,6 +541,32 @@ multi method path(URI:D: Str() $path) returns Path:D {
 }
 
 multi method segments(URI:D:) returns List:D { $!path.segments }
+
+multi method segments(URI:D: @segments where *.elems > 0) returns List:D {
+    my $path = @segments.join('/');
+    given self!gister(:$path) -> $source {
+        for @segments -> $bad-segment {
+            X::URI::Path::Invalid.new(
+                :$source,
+                :$path,
+                :$bad-segment,
+            ).throw if $bad-segment.contains("/");
+        }
+
+        self!check-path(:$path, :$source);
+    }
+
+    $!path = Path.new(
+        path     => $path,
+        segments => @segments.map(*.Str),
+    );
+    $!path.segments;
+}
+
+multi method segments(URI:D: $first-segment, *@remaining-segments) returns List:D {
+    my @segments = $first-segment, |@remaining-segments;
+    self.segments(@segments);
+}
 
 my $warn-deprecate-abs-rel = q:to/WARN-END/;
     The absolute and relative methods are artifacts carried over from an old

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -83,7 +83,7 @@ class Path {
 
         my @segments := $path<segment>.list.map({.Str}).List || ('',);
         if my $first_chunk = $path<segment-nz-nc> || $path<segment-nz> {
-            @segments := ($first_chunk, |@segments);
+            @segments := ($first_chunk.Str, |@segments);
         }
         if @segments.elems == 0 {
             @segments := ('',);
@@ -412,16 +412,19 @@ method !check-path(
     :$path          = $.path,
     :$source        = $.gist,
 ) {
-    my &path-regex := $has-authority ?? &path-authority
-                   !! $has-scheme    ?? &path-scheme
-                   !!                   &path-plain
-                   ;
-
-    if $path ~~ &path-regex -> $comp {
-        return $comp;
-    }
-    else {
-        X::URI::Invalid.new(:$source).throw
+    with X::URI::Invalid.new(:$source) -> \ex {
+        if $has-authority {
+            ex.throw unless $path ~~ /^ <path-authority> $/;
+            return $<path-authority>;
+        }
+        elsif $has-scheme {
+            ex.throw unless $path ~~ /^ <path-scheme> $/;
+            return $<path-scheme>;
+        }
+        else {
+            ex.throw unless $path ~~ /^ <path-plain> $/;
+            return $<path-plain>;
+        }
     }
 }
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -108,8 +108,138 @@ class Path {
     multi method Str() { $!path }
 }
 
-our subset Query of Str
-    where /^ <IETF::RFC_Grammar::URI::query> $/;
+class Query does Positional does Associative does Iterable {
+    our subset ValidQuery of Str
+        where /^ <IETF::RFC_Grammar::URI::query> $/;
+
+    our enum HashFormat <Mixed Singles Lists>;
+
+    has HashFormat $.hash-format is rw;
+    has ValidQuery $!query;
+    has Pair @!query-form;
+
+    multi method new(Str() $query) {
+        self.new(:$query);
+    }
+
+    submethod BUILD(:$!query, :@!query-form, :$!hash-format = Lists) {
+        die "When calling URI::Query.new set either :query or :query-form, but not both."
+            if @!query-form and $!query;
+
+        @!query-form = split-query($!query) if $!query;
+    }
+
+    method !value-for($key) {
+        # TODO Is there a better way to make this list immutable than to use a
+        # Proxy container?
+        my $l = @!query-form.grep({ .key eq $key }).map({
+            my $v = .value;
+            Proxy.new(
+                FETCH => method () { $v },
+                STORE => method ($n) { X::Assignment::RO.new.throw },
+            );
+        }).List;
+
+        given $!hash-format {
+            when Mixed   { $l.elems == 1 ?? $l[0] !! $l }
+            when Singles { $l.first(:end) }
+            default      { $l }
+        }
+    }
+
+    method of() { Pair }
+    method iterator() { @!query-form.iterator }
+
+    # positional context
+    method AT-POS(Query:D: $i)     { @!query-form[$i] }
+    method EXISTS-POS(Query:D: $i) { @!query-form[$i]:exists }
+    method ASSIGN-POS(Query:D: $i, Pair $p) {
+        $!query = Nil;
+        @!query-form[$i] = $p;
+    }
+    method DELETE-POS(Query:D: $i) {
+        $!query = Nil;
+        @!query-form[$i]:delete
+    }
+
+    # associative context
+    method AT-KEY(Query:D: $k)     { self!value-for($k) }
+    method EXISTS-KEY(Query:D: $k) { @!query-form.first({ .key eq $k }).defined }
+    method ASSIGN-KEY(Query:D: $k, $value) {
+        $!query = Nil;
+        @!query-form .= grep({ .key ne $k });
+
+        given $!hash-format {
+            when Singles {
+                @!query-form.push: $k => $value;
+            }
+            default {
+                @!query-form.append: $value.list.map({ $k => $^v });
+            }
+        }
+
+        $value
+    }
+    method DELETE-KEY(Query:D: $k) {
+        $!query = Nil;
+        my $r = self!value-for($k);
+        my @ps = @!query-form .= grep({ .key ne $k });
+        $r;
+    }
+
+    # Hash-like readers
+    method values(Query:D:) { @!query-form».value }
+    method kv(Query:D:) { @!query-form».kv.flat }
+    method pairs(Query:D:) { @!query-form }
+
+    # Array-like manipulators
+    method pop(Query:D:) { $!query = Nil; @!query-form.pop }
+    method push(Query:D: |c) { $!query = Nil; @!query-form.push: |c }
+    method append(Query:D: |c) { $!query = Nil; @!query-form.append: |c }
+    method shift(Query:D:) { $!query = Nil; @!query-form.shift }
+    method unshift(Query:D: |c) { $!query = Nil; @!query-form.unshift: |c }
+    method prepend(Query:D: |c) { $!query = Nil; @!query-form.prepend: |c }
+    method splice(Query:D: |c) { $!query = Nil; @!query-form.splice: |c }
+
+    # Array-like readers
+    method elems(Query:D:) { @!query-form.elems }
+    method end(Query:D:) { @!query-form.end }
+
+    method Bool(Query:D: |c) { @!query-form.Bool }
+    method Int(Query:D: |c) { @!query-form.Int }
+    method Numeric(Query:D: |c) { @!query-form.Numeric }
+    method Capture(Query:D: |c) { @!query-form.Capture }
+
+    multi method query(Query:D:) {
+        return $!query with $!query;
+        $!query = @!query-form.grep({ .defined }).map({
+            if .value eqv True {
+                uri-escape(.key)
+            }
+            else {
+                "{uri-escape(.key)}={uri-escape(.value)}"
+            }
+        }).join('&');
+    }
+
+    multi method query(Query:D: Str() $new) {
+        $!query = $new;
+        @!query-form = split-query($!query) if $!query;
+        $!query;
+    }
+
+    multi method query-form(Query:D:) { @!query-form }
+
+    multi method query-form(Query:D: *@new, *%new) {
+        $!query = Nil;
+        @!query-form = flat %new, @new;
+    }
+
+    # string context
+    multi method gist() { $.query }
+    multi method Str() { $.gist }
+
+}
 
 our subset Fragment of Str
     where /^ <IETF::RFC_Grammar::URI::fragment> $/;
@@ -120,9 +250,8 @@ has Bool $.match-prefix = False;
 has Path $.path = Path.new;
 has Scheme $.scheme is rw = '';
 has Authority $.authority is rw;
-has Query $.query = '';
+has Query $.query = Query.new('');
 has Fragment $.fragment is rw = '';
-has %!query-form; # cache query-form
 has $!uri;  # use of this now deprecated
 
 method parse (Str $str, :$match-prefix) {
@@ -135,10 +264,9 @@ method parse (Str $str, :$match-prefix) {
     $!scheme    = '';
     $!authority = Nil;
     $!path      = Path.new;
-    $!query     = '';
+    $!query.query('');
     $!fragment  = '';
     $!uri = Mu;
-    %!query-form := Map.new();
 
     if ($!match-prefix or $match-prefix) {
         $!grammar.subparse($c_str);
@@ -159,7 +287,7 @@ method parse (Str $str, :$match-prefix) {
         $!grammar.parse_result<URI-reference><relative-ref>;
 
     $!scheme = .lc with $comp_container<scheme>;
-    $!query = .Str with $comp_container<query>;
+    $!query.query(.Str) with $comp_container<query>;
     $!fragment = .lc with $comp_container<fragment>;
     $comp_container = $comp_container<hier-part> || $comp_container<relative-part>;
 
@@ -168,49 +296,69 @@ method parse (Str $str, :$match-prefix) {
     }
 
     $!path = Path.new($comp_container);
-
-    try {
-        %!query-form := split-query( $!query, :immutable ) if $!query;
-        CATCH {
-            default {
-                %!query-form = ();
-            }
-        }
-    }
 }
 
-our sub split-query(Str $query, Bool :$immutable = False) {
-    my %query-form;
+our sub split-query(
+    Str $query,
+    Bool :$immutable = False,
+    :$as-hash = False, # maybe :as-hash<mixed>/:as-hash<single> someday?
+) {
 
-    for map { [split(/<[=]>/, $_) ]}, split(/<[&;]>/, $query) -> $qmap {
-        for (0, 1) -> $i { # could go past 1 in theory ...
-            $qmap[ $i ] = uri-unescape($qmap[ $i ]);
+    my @query-form = gather for $query.split(/<[&;]>/) {
+        # when the query component contains abc=123 form
+        when /'='/ {
+            my ($k, $v) = .split('=', 2).map(&uri-unescape);
+            take $k => $v;
         }
-        if %query-form{$qmap[0]}:exists {
-            if %query-form{ $qmap[0] } ~~ Array  {
-                %query-form{ $qmap[0] }.push($qmap[1])
+
+        # or if the component contains just abc
+        default {
+            take $_ => True;
+        }
+    }
+
+    # They have requested a mixed hash form
+    if $as-hash {
+        my %query-form;
+
+        for @query-form -> $qp {
+            if %query-form{ $qp.key }:exists {
+                if %query-form{ $qp.key } ~~ Array {
+                    %query-form{ $qp.key }.push: $qp.value;
+                }
+                else {
+                    %query-form{ $qp.key } = [
+                        %query-form{ $qp.key },
+                        $qp.value,
+                    ];
+                }
             }
             else {
-                %query-form{ $qmap[0] } = [
-                    %query-form{ $qmap[0] }, $qmap[1]
-                ]
+                %query-form{ $qp.key } = $qp.value;
             }
         }
+
+        if $immutable {
+            # Convert to Lists and Maps to make immutable
+            for %query-form.kv -> $k, $v {
+                %query-form{$k} = $v.List
+                    if $v ~~ Array;
+            }
+
+            return %query-form.Map;
+        }
         else {
-            %query-form{ $qmap[0]} = $qmap[1]
+            return %query-form;
         }
     }
 
-    if $immutable {
-        # Convert to Lists and Maps to make immutable
-        for %query-form.kv -> $k, $v {
-            %query-form{$k} = $v.List
-                if $v ~~ Array;
-        }
-        %query-form.Map;
+    elsif $immutable {
+        # Convert to List
+        return @query-form.List;
     }
+
     else {
-        %query-form;
+        return @query-form;
     }
 }
 
@@ -362,14 +510,8 @@ method relative {
 
 multi method query(URI:D:) { $!query }
 
-multi method query(URI:D: Query $new) {
-    $!query = $new;
-    if $!query {
-        %!query-form := split-query($!query, :immutable);
-    }
-    else {
-        %!query-form := Map.new();
-    }
+multi method query(URI:D: Query::ValidQuery $new) {
+    $!query.query($new);
 }
 
 method path-query {
@@ -411,66 +553,9 @@ method uri {
     $!uri;
 }
 
-multi method query-form() returns Map:D {
-    %!query-form;
-}
+multi method query-form() { $!query }
 
-method !query-from-query-form(:$delimiter is copy) {
-    my @query = gather for %!query-form.kv -> $key is copy, $vals {
-		$key //= '';
-        $key = uri-escape($key);
-        for @($vals) -> $val is copy {
-            $val //= '';
-            $val  = uri-escape($val);
-            $val .= trans(" " => "+");
-            take "$key=$val";
-        }
-    }
-
-    unless $delimiter {
-
-        # if no delimiter spec'd, prefer the object delim
-        $delimiter //= $.query-form-delimiter;
-
-        # if no object delim, detect from previous value
-        if !$delimiter && $!query ~~ /(<[&;]>)/ -> $d {
-            $delimiter = $d[0];
-        }
-
-        # if nothing detected, use the ultimate default
-        $delimiter //= '&';
-    }
-
-	$!query = join $delimiter, @query;
-}
-
-multi method query-form(*@replace, *%replace, :$delimiter) {
-    my @pairs = flat @replace».kv, %replace.kv;
-
-    my %qacc;
-    for @pairs -> $k, $v {
-        if %qacc{$k} ~~ Array {
-            %qacc{$k}.push: $v;
-        }
-        elsif %qacc{$k}:exists {
-            %qacc{$k} = [ %qacc{$k}, $v ];
-        }
-        else {
-            %qacc{$k} = $v;
-        }
-    }
-
-    # %!query-form must be immutable
-    for %qacc.kv -> $k, $v {
-        %qacc{$k} = $v.List
-            if $v ~~ Array;
-    }
-    %!query-form := %qacc.Map;
-
-    self!query-from-query-form(:$delimiter);
-
-    %!query-form;
-}
+multi method query-form(|c) { $!query.query-form(|c) }
 
 method query_form { $.query-form }
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -30,8 +30,8 @@ class X::URI::Authority::Invalid is X::URI::Invalid {
 }
 
 class Authority {
-    has Userinfo $.userinfo is required is rw = '';
-    has Host $.host is required is rw where *.chars > 0;
+    has Userinfo:D $.userinfo is default('') is rw = '';
+    has Host:D $.host is required is rw where *.chars > 0;
     has Port $.port is rw;
 
     multi method new(Authority:U: IETF::RFC_Grammar:D $grammar, Str:D $authority) {
@@ -471,7 +471,7 @@ multi method host(URI:D: Str() $new) returns Host {
             source => self!gister(authority => $new),
         );
 
-        $!authority .= new(host => $new);
+        $!authority .= new(host => $new, userinfo => '');
         $!authority.host;
     }
 
@@ -514,16 +514,7 @@ multi method authority(URI:D:) returns Authority {
     $!authority;
 }
 
-multi method authority(URI:D: Nil) returns Authority:U {
-    with $!authority {
-        self!check-path(:!has-authority,
-            source => self!gister(authority => ''),
-        );
-    }
-    $!authority = Nil;
-}
-
-multi method authority(URI:D: Str() $authority) returns Authority:D {
+multi method authority(URI:D: Str() $authority) returns Authority {
     if $authority ne '' {
         without $!authority {
             self!check-path(:has-authority,
@@ -622,11 +613,11 @@ method !gister(
     :$fragment = $.fragment,
 ) {
     my Str $s;
-    $s ~= $scheme if $scheme;
-    $s ~= '://' ~ $authority if $authority;
+    $s ~= "$scheme:"     if $scheme;
+    $s ~= "//$authority" if $authority;
     $s ~= $path;
-    $s ~= '?' ~ $query if $query;
-    $s ~= '#' ~ $fragment if $fragment;
+    $s ~= "?$query"      if $query;
+    $s ~= "#$fragment"   if $fragment;
     $s;
 }
 
@@ -851,12 +842,9 @@ This will throw an C<X::URI::Invalid> exception if adding or removing the scheme
 =head2 method authority
 
     multi method authority(URI:D:) returns URI::Authority
-    multi method authority(URI:D: Authority $new) returns URI::Authority
     multi method authority(URI:D: Str() $new) returns URI::Authority
 
 Returns the C<URI::Authority> for the current URI object. This may be an undefined type object if no authority has been set or found during parse.
-
-When passed a C<URI::Authority> (or C<Nil>), the authority will be updated to point to the given object.
 
 When passed a string, the string will have the authority parsed out of it and a new authority object will be used to store the parsed information.
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -16,15 +16,9 @@ our subset Scheme of Str
         || <IETF::RFC_Grammar::URI::scheme>
     ] $/;
 our subset Userinfo of Str
-    where /^ [
-           ''
-        || <IETF::RFC_Grammar::URI::userinfo>
-    ] $/;
+    where /^ [ <IETF::RFC_Grammar::URI::userinfo> ] $/;
 our subset Host of Str
-    where /^ [
-           ''
-        || <IETF::RFC_Grammar::URI::host>
-    ] $/;
+    where /^ [ <IETF::RFC_Grammar::URI::host> ] $/;
 our subset Port of UInt;
 
 class X::URI::Authority::Invalid is X::URI::Invalid {
@@ -36,8 +30,8 @@ class X::URI::Authority::Invalid is X::URI::Invalid {
 }
 
 class Authority {
-    has Userinfo $.userinfo is rw = '';
-    has Host $.host is required;
+    has Userinfo $.userinfo is required is rw = '';
+    has Host $.host is required is rw where *.chars > 0;
     has Port $.port is rw;
 
     multi method new(Authority:U: IETF::RFC_Grammar:D $grammar, Str:D $authority) {
@@ -87,7 +81,7 @@ class Path {
         my $path-type = @rules.first({ $comp{ $_ }.defined });
         my $path = $comp{ $path-type };
 
-        my @segments := $path<segment>.list.map({.Str}).list || ('',);
+        my @segments := $path<segment>.list.map({.Str}).List || ('',);
         if my $first_chunk = $path<segment-nz-nc> || $path<segment-nz> {
             @segments := ($first_chunk, |@segments);
         }
@@ -188,6 +182,7 @@ class Query does Positional does Associative does Iterable {
     }
 
     # Hash-like readers
+    method keys(Query:D:) { @!query-form».key }
     method values(Query:D:) { @!query-form».value }
     method kv(Query:D:) { @!query-form».kv.flat }
     method pairs(Query:D:) { @!query-form }
@@ -208,7 +203,6 @@ class Query does Positional does Associative does Iterable {
     method Bool(Query:D: |c) { @!query-form.Bool }
     method Int(Query:D: |c) { @!query-form.Int }
     method Numeric(Query:D: |c) { @!query-form.Numeric }
-    method Capture(Query:D: |c) { @!query-form.Capture }
 
     multi method query(Query:D:) {
         return $!query with $!query;
@@ -527,15 +521,6 @@ multi method authority(URI:D: Nil) returns Authority:U {
         );
     }
     $!authority = Nil;
-}
-
-multi method authority(URI:D: Authority:D $new) returns Authority:D {
-    without $!authority {
-        self!check-path(:has-authority,
-            source => self!gister(authority => ~$new),
-        );
-    }
-    $!authority = $new;
 }
 
 multi method authority(URI:D: Str() $authority) returns Authority:D {
@@ -1071,85 +1056,284 @@ This is a subset of C<Str> that only accepts valid URI fragments.
 
 =head2 URI::Authority
 
-=head3 method new
+The C<authority> method of a URI constructs or returns this object.
+
+It is recommended that you do not costruct a C<URI::Authority> object directly, but let the methods of C<URI> handle construction.
 
 =head3 method userinfo
 
+    method userinfo(URI::Authority:D:) is rw returns URI::Userinfo:D
+
+This is a simple setter/getter for the userinfo on the authority. It must be defined, but may be the empty string. If not empty, it must be valid for the userinfo component of a URI.
+
 =head3 method host
+
+    method host(URI::Authority:D:) is rw returns URI::Host:D
+
+This is a simple setter/getter for the host part of the URI authority. It must be defined and it must not be empty. It must be valid as a host for the authority component of the URI.
 
 =head3 method port
 
+    method port(URI::Authority:D:) is rw returns URI::Port
+
+This is a simple setter/getter for the port part of the URI authority. It may be set to an undefined value if no explicit port is set in the authority. If defined, it must an unsigned integer.
+
 =head3 method gist
+
+    multi method gist(URI::Authority:D:) returns Str:D
+
+Returns the string representation of the URI authority. For example,
+
+    my $u = URI.new("http://steve@example.com:8008");
+
+    # say calls .gist
+    say $u.authority; #> "steve@example.com:8080";
 
 =head3 method Str
 
+    multi method gist(URI::Authority:D:) returns Str:D
+
+Stringifies identical to C<gist>.
+
 =head2 URI::Path
+
+This class is used to represent URI path components.
 
 It is recommended that you do not construct a C<URI::Path> object directly, but rely on the C<path> setter in C<URI> instead.
 
 =head3 method path
 
+    method path(URI::Path:D:) returns Str:D
+
+Returns the string representation of the path.
+
 =head3 method segments
+
+    method segments(URI::Path:D:) returns List:D
+
+Returns a list representation of the path segments. In a URI, the path segments are the strings between slashes ("/").
 
 =head3 method gist
 
+    method gist(URI::Path:D:) returns Str:D
+
+Returns the C<path>.
+
 =head3 method Str
+
+    method Str(URI::Path:D:) returns Str:D
+
+Returns the C<path>.
 
 =head2 URI::Query
 
+This class is used to represent a URI query component. This class may be safely constructed and used independently of the URI object.
+
+It behaves as both a positional and associative object and is iterable. Internally, it is stored as an C<Array> of C<Pair>s. You must not treat this object purely as you would an C<Array> or purely as you would a C<Hash> as some methods will not work the way you expect.
+
+The performance of the associative methods is not guaranteed and is probably going to be relatively slow. This implementation values simplicity and accuracy of representation to CPU performance. If you need something that is better for CPU performance, you should investigate the use of another library, such as C<Hash::MultiValue>.
+
 =head3 method new
+
+    multi method new(Str() $query) returns URI::Query:D
+    multi method new(:$query) returns URI::Query:D
+
+Constructs a new C<URI::Query> from the given string, which may be empty.
 
 =head3 enum HashFormat
 
+This enumeration provides the values that may be set on C<hash-format> on a C<URI::Query>. Possible values are as follows.
+
+=head4 URI::Query::List
+
+This is the default and recommended value. When set in C<hash-format>, each key in the hash representation will point to a list of one or more values.
+
+This is recommended as it is the most accurate representation to what is actually possible in a query string. The values within each key will be sorted in the same order as they appear in the query.
+
+=head4 URI::Query::Mixed
+
+When set in C<hash-format>, each key in the hash representation may be mapped to either a list of two or more values, or to the value itself if there is only one.
+
+This is not recommended because it means that setting a key to an iterable value will be treated as multiple key-value pairs when it comes time to render the query as a string. This could have unintended consequences.
+
+=head4 URI::Query::Singles
+
+When set in C<hash-format>, each key in the hash representation will be mapped directly to a single value. If there are multiple values that have been set in the query, then only the last will be visible through the hash representation.
+
+This is not recommended because it may hide certain values, but may be useful for simple applications that treat the query string as having unique values. Just note that the trade-off is that your application may be confused when multiple values are present.
+
+=head4 URI::Query::None
+
+This value should not be used, but will be treated the same as C<URI::Query::List> if used. It is intended for internal use.
+
 =head3 method hash-format
+
+    method hash-format(URI::Query:D) is rw returns URI::Query::HashFormat
+
+This is a simple setter/getter for setting the way in which associative lookups are performed. See C<enum URI::Query::HashFormat> for a description of each mode.
 
 =head3 method query
 
+    method query(Query:D:) returns URI::Query::ValidQuery:D
+    method query(Query:D: Str() $new) returns URI::Query::ValidQuery:D
+
+This method returns the string representation of the URI query component. When passed a string, it will replace the query with the new value and will use C<split-query> to parse that query into an array of C<Pair>s.
+
+The primary representation of the queryo object is the value returned by C<query-form>. The C<query> is cached to keep the value stored in it when this method is called to set it or when C<URI::Query> is constructed from a string. Any modification to the internal array of pairs, though, will clear this cache. It  will be generated the next time the C<query> method is called and that string will be cached.
+
 =head3 method query-form
+
+    method query-form(Query:D:) returns Array:D
+    method query-form(Query:D: *@new, *%new) returns Array:D
+
+This method returns the array of C<Pair>s that store the internal representation of the URI query component. When passed an array of C<Pair>s, it will replace the current value with that array.
+
+A quick note about the way pairs are passed as parameters to a method, you most likely want to avoid passing values as named parameters. If values are passed using unquoted strings, they will be treated as named parameters, which is most likely what you want:
+
+    my $q = URI::Query.new;
+
+    # Prefer this
+    $q.query-form('foo' => 1, 'bar' => 2, 'foo' => 3);
+
+    # Avoid these
+    $q.query-form(foo => 1, bar => 2, foo => 3);
+    $q.query-form(:foo(1), :bar(2), :foo(3));
+
+The latter two will result in the first "foo" pair being lost. Named parameters assume unique names and the latter "foo" key will effectively override the former.
+
+That said, the method will allow hashes to be passed in, if that is your preference.
 
 =head3 method of
 
+    method of()
+
+Always returns C<Pair>.
+
 =head3 method iterator
+
+    method iterator(Query:D:) returns Iterator:D
+
+Returns the iterator on the internal array of C<Pair>s.
 
 =head3 method postcircumflex:<[ ]>
 
+    method postcircumflex:<[ ]> returns Pair
+
+This permits positional access to each C<Pair> stored internally. You may use this to get a C<Pair>, set a C<Pair>, test for existence, or delete.
+
 =head3 method postcircumflex:<{ }>
+
+    method postcircumflex:<{ }>
+
+This permits associative access to the values stored internally by key. What is returned here when fetching values depends on the setting in C<hash-format>, a list of one or more values or C<Nil>, by default. You can use this for getting, setting, existence testing, or deletion.
+
+=head3 method keys
+
+    method keys(Query:D:) returns Seq:D
+
+This method returns all the keys of the query in order.
 
 =head3 method values
 
+    method values(Query:D:) returns Seq:D
+
+This method returns all the values of the query in order.
+
 =head3 method kv
+
+    method kv(Query:D:) returns Seq:D
+
+This method returns a sequence alternating the keys and values of the query in order.
 
 =head3 method pairs
 
+    method kv(Query:D:) returns Seq:D
+
+This method returns a copy of the internal representation of the query string array.
+
 =head3 method pop
+
+    method pop(Query:D:) returns Pair
+
+This method removes the last Pair from the array of pairs and returns it.
 
 =head3 method push
 
+    method push(Query:D: *@new)
+
+This method adds the given pairs to the end of the array of pairs in the query using push semantics.
+
 =head3 method append
+
+    method append(Query:D: *@new)
+
+This method adds the given pairs to the end of the array of pairs in the query using append semantics.
 
 =head3 method shift
 
+    method shift(Query:D:) returns Pair
+
+This method removes the first Pair from the array of pairs and returns it.
+
 =head3 method unshift
+
+    method unshift(Query:D: *@new)
+
+This method adds the given pairs to the front of the array of pairs in the query using unshift semantics.
 
 =head3 method prepend
 
+    method prepend(Query:D: *@new)
+
+This method adds the given pairs to the front of the array of pairs in the query using prepend semantics.
+
 =head3 method splice
+
+    method splice(Query:D: $start, $elems?, *@replacement)
+
+This method removes a C<$elems> number of pairs from the array of pairs in the query starting at index C<$start>. It then inserts the pairs in C<@replacement> into that part of the array (if any are given).
 
 =head3 method elems
 
+    method elems(Query:D:) returns Int:D
+
+Returns the number of pairs stored in the query.
+
 =head3 method end
+
+    method end(Query:D:) returns Int:D
+
+Returns the index of the last pair stored in the query.
 
 =head3 method Bool
 
+    method Bool(Query:D:) returns Bool:D
+
+Returns C<True> if the at least one pair is stored in the query or C<False> otherwise.
+
 =head3 method Int
+
+    method Int(Query:D:) returns Int:D
+
+Returns C<elems>.
 
 =head3 method Numeric
 
-=head3 method Capture
+    method Numeric(Query:D:) returns Int:D
+
+Returns C<elems>.
 
 =head3 method gist
 
+    method gist(Query:D:) returns Str:D
+
+Returns the C<query>.
+
 =head3 method Str
+
+    method Str(Query:D:) returns Str:D
+
+Returns the C<query>.
 
 =head1 EXCEPTIONS
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -26,11 +26,44 @@ our subset Host of Str
         || <IETF::RFC_Grammar::URI::host>
     ] $/;
 our subset Port of UInt;
-our subset Authority of Str
-    where /^ [
-           ''
-        || <IETF::RFC_Grammar::URI::authority>
-    ] $/;
+
+class X::URI::Authority::Invalid is Exception {
+    has $.source;
+    method message { "Could not parse authority: $!source" }
+}
+
+class Authority {
+    has Userinfo $.userinfo is rw = '';
+    has Host $.host is required;
+    has Port $.port is rw;
+
+    multi method new(Authority:U: IETF::RFC_Grammar:D $grammar, Str:D $authority) {
+        $grammar.parse($authority, rule => 'authority');
+        if not $grammar.parse_result {
+            X::URI::Authority::Invalid.new(source => $authority).throw;
+        }
+
+        self.new($grammar.parse_result);
+    }
+
+    multi method new(Authority:U: Match:D $auth) {
+        my Str $userinfo = do with $auth<userinfo> { .Str } else { '' }
+        my Str $host     = "$auth<host>".lc;
+        my UInt $port    = do with $auth<port> { .Int } else { Nil }
+
+        self.new(:$userinfo, :$host, :$port);
+    }
+
+    multi method gist() {
+        my $authority = '';
+        $authority ~= "$!userinfo@" if $!userinfo;
+        $authority ~= $!host;
+        $authority ~= ":$!port" if $!port;
+        $authority;
+    }
+
+    multi method Str() { $.gist }
+}
 
 # Caveat: This subset is not sensitive to context, so may permit a path that is
 # not valid for the current URI. So, the mutator is more particular.
@@ -54,9 +87,7 @@ has $.grammar;
 has Bool $.match-prefix = False;
 has Path $.path = '';
 has Scheme $.scheme is rw = '';
-has Userinfo $.userinfo is rw = '';
-has Host $.host = '';
-has Port $._port is rw;
+has Authority $.authority is rw;
 has Query $.query = '';
 has Fragment $.fragment is rw = '';
 has %!query-form; # cache query-form
@@ -71,11 +102,11 @@ method parse (Str $str, :$match-prefix) {
     $c_str .= subst(/^ \s* ['<' | '"'] /, '');
     $c_str .= subst(/ ['>' | '"'] \s* $/, '');
 
-    $!scheme   = '';
-    $!_port    = Nil;
-    $!path     = '';
-    $!query    = '';
-    $!fragment = '';
+    $!scheme    = '';
+    $!authority = Nil;
+    $!path      = '';
+    $!query     = '';
+    $!fragment  = '';
     $!uri = Mu;
     %!query-form := Map.new();
     @!segments := ();
@@ -103,10 +134,9 @@ method parse (Str $str, :$match-prefix) {
     $!fragment = .lc with $comp_container<fragment>;
     $comp_container = $comp_container<hier-part> || $comp_container<relative-part>;
 
-    my $authority = $comp_container<authority>;
-    $!userinfo    = .Str with $authority<userinfo>;
-    $!host        = "$authority<host>".lc || '';
-    $!_port       = .Int with $authority<port>;
+    with $comp_container<authority> -> $auth {
+        $!authority = Authority.new($auth);
+    }
 
     # share code with the path mutator
     self!make-path($comp_container);
@@ -182,30 +212,32 @@ multi method new(Str :$uri, :$match-prefix) {
     return self.new($uri, :$match-prefix);
 }
 
-multi method authority(URI:D:) returns Authority:D {
-    my $authority = '';
-    $authority ~= "$!userinfo@" if $!userinfo;
-    $authority ~= $!host // '';
-    $authority ~= ":$!_port" if $!_port;
-    $authority;
+multi method userinfo(URI:D:) returns Userinfo {
+    .userinfo with $!authority
 }
 
-multi method authority(URI:D: Authority:D $new) {
-    $!userinfo = '';
-    $!_port    = Nil;
-
-    if $new ~~ /
-        $<authority> = <IETF::RFC_Grammar::URI::authority>
-    / -> $comp {
-        $!userinfo = .Str with $comp<authority><userinfo>;
-        $!host     = ($comp<authority><host> // '').Str.lc;
-        $!_port    = .Int with $comp<authority><port>;
+multi method userinfo(URI:D: Userinfo $new) {
+    with $!authority {
+        .userinfo = $new;
     }
     else {
-        $!host = '';
+        X::URI::Authority::Invalid.new(
+            soruce => "$new@",
+        ).throw
     }
+}
 
-    return;
+multi method host(URI:D:) returns Host {
+    .host with $!authority;
+}
+
+multi method host(URI:D: Host $new) {
+    with $!authority {
+        .host = $new;
+    }
+    else {
+        $!authority .= new(host => $new);
+    }
 }
 
 method default-port {
@@ -213,14 +245,33 @@ method default-port {
 }
 method default_port { $.default-port() } # artifact form
 
-multi method port(URI:D:) returns Port { $!_port // $.default-port }
+multi method _port(URI:D:) returns Port {
+    return-rw .port with $!authority;
+}
+
+multi method port(URI:D:) returns Port { $._port // $.default-port }
 
 multi method port(URI:D: Port $new) {
-    $!_port = $new;
+    with $!authority {
+        .port = $new;
+    }
+    else {
+        X::URI::Authority::Invalid.new(
+            source => ":$new",
+        ).throw
+    }
 }
 
 multi method port(URI:D: Nil) {
-    $!_port = Nil;
+    .port = Nil with $!authority;
+}
+
+multi method authority(URI:D: Str:D $authority) returns Authority:D {
+    $!authority = Authority.new($!grammar, $authority);
+}
+
+multi method authority(URI:D:) is rw returns Authority:D {
+    return-rw $!authority;
 }
 
 my regex URI-paths {

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -432,14 +432,14 @@ multi method scheme(URI:D: Str() $scheme) returns Scheme:D {
 
 multi method userinfo(URI:D:) returns Userinfo {
     return .userinfo with $!authority;
-    Nil;
+    '';
 }
 
 multi method userinfo(URI:D: Str() $new) returns Userinfo {
     with $!authority {
         .userinfo = $new;
     }
-    else {
+    elsif $new ne '' {
         X::URI::Authority::Invalid.new(
             before => 'userinfo',
             source => "$new@",
@@ -449,24 +449,23 @@ multi method userinfo(URI:D: Str() $new) returns Userinfo {
 
 multi method host(URI:D:) returns Host {
     return .host with $!authority;
-    Nil;
-}
-
-multi method host(URI:D: Nil) returns Host {
-    with $!authority {
-        self!check-path(:!has-authority,
-            source => self!gister(authority => ''),
-        );
-
-        $!authority = Nil;
-    }
+    '';
 }
 
 multi method host(URI:D: Str() $new) returns Host {
     with $!authority {
-        .host = $new;
+        if $new eq '' {
+            self!check-path(:!has-authority,
+                source => self!gister(authority => ''),
+            );
+
+            $!authority = Nil;
+        }
+        else {
+            .host = $new;
+        }
     }
-    else {
+    elsif $new ne '' {
         self!check-path(:has-authority,
             source => self!gister(authority => $new),
         );
@@ -474,6 +473,8 @@ multi method host(URI:D: Str() $new) returns Host {
         $!authority .= new(host => $new);
         $!authority.host;
     }
+
+    $new;
 }
 
 method default-port(URI:D:) returns Port {
@@ -844,9 +845,43 @@ This will throw an C<X::URI::Invalid> exception if adding or removing the scheme
 
 =head2 method authority
 
+    multi method authority(URI:D:) returns URI::Authority
+    multi method authority(URI:D: Authority $new) returns URI::Authority
+    multi method authority(URI:D: Str() $new) returns URI::Authority
+
+Returns the C<URI::Authority> for the current URI object. This may be an undefined type object if no authority has been set or found during parse.
+
+When passed a C<URI::Authority> (or C<Nil>), the authority will be updated to point to the given object.
+
+When passed a string, the string will have the authority parsed out of it and a new authoirty object will be used to store the parsed information.
+
+When passing an argument, this will throw an C<X::URI::Invalid> exception if setting or clearing the authority on the URI will make the URI invalid. See SCHEME, AUTHORITY, AND PATH section for details.
+
+The authority is made up of three components: userinfo, host, and port. Of those, host is the only required component. Additional methods are provided for accessing each of those parts separately.
+
 =head2 method userinfo
 
+    multi method userinfo(URI:D:) returns URI::Userinfo:D
+    multi method userinfo(URI:D: Str() $new) returns URI::Userinfo:D
+
+The userinfo is an optional component of the URI authority. This method returns the current userinfo or an empty string.
+
+It may not set to a non-empty string unless an authority with a host is already in place.
+
+Passing a non-empty string to this method while no authority is set will result in a C<X::URI::Authority::Invalid> exception.
+
 =head2 method host
+
+    multi method host(URI:D:) returns URI::Host:D
+    multi method host(URI:D: Str() $new) returns URI::Host:D
+
+The host is a required component of the URI authority (the only required component). This method returns the current host or an empty string.
+
+Setting this to a non-empty string where no authority was set before will cause a new C<URI::Authority> to be constructed. This will result in a check to make sure the URI is still valid.
+
+Setting this to an empty string when an authority is set will cause the C<URI::Authority> to be removed from the URI and will also clear the userinfo and port. This will also result in a check to make sure th URI is still valid.
+
+If a validity check fails (because having or not having an authority means the path that is set is no longer valid), a C<X::URI::Invalid> exception will be thrown.
 
 =head2 method default-port
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -1349,6 +1349,56 @@ This exception is a subclass of C<X::URI::Invalid>. It is thrown whenever the au
 
 In this case, C<source> will refer to the authority only and a C<before> accessor names the part of the authority that was being set before C<host>.
 
+=head1 AUTHORS
+
+Contributors to this module include:
+
+=item Ronald Schmidt (ronaldxs)
+
+=item Moritz Lentz (moritz)
+
+=item Nick Logan (ugexe)
+
+=item Tobias Leich (FROGGS)
+
+=item Jonathan Stowe (jonathanstowe)
+
+=item Justin DeVuyst (jdv)
+
+=item Solomon Foster (colomon)
+
+=item Roman Baumer (rba)
+
+=item Zoffix Znet (zoffixznet)
+
+=item Ahmad M. Zawawi (azawawi)
+
+=item Gabor Szabo (szabgab)
+
+=item Samantha McVey (samcv)
+
+=item Pawel Pabian (bbkr)
+
+=item Rob Hoelz (hoelzro)
+
+=item radiak
+
+=item Paul Cochrane (paultcochrane)
+
+=item Steve Mynott (stmuk)
+
+=item timo
+
+=item David Warring (dwarring)
+
+=item Sterling Hanenkamp (zostay)
+
+=head1 COPYRIGHT & LICENSE
+
+Copyright 2017 Ronald Schmidt.
+
+This software is licensed under the same license as Perl 6 itself.
+
 =end pod
 
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -244,7 +244,6 @@ class Query does Positional does Associative does Iterable {
 our subset Fragment of Str
     where /^ <IETF::RFC_Grammar::URI::fragment> $/;
 
-has Str $.query-form-delimiter;
 has $.grammar;
 has Bool $.match-prefix = False;
 has Path $.path = Path.new;
@@ -357,7 +356,7 @@ our sub split-query(
 }
 
 # artifact form
-our sub split_query(Str $query) { split-query($query) }
+our sub split_query(|c) { split-query(|c) }
 
 # deprecated old call for parse
 method init ($str) {
@@ -371,15 +370,15 @@ submethod BUILD(:$match-prefix) {
     $!grammar = IETF::RFC_Grammar.new('rfc3986');
 }
 
-multi method new(Str $uri, :$match-prefix) {
+multi method new(URI:U: $uri, Bool :$match-prefix) {
     my $obj = self.bless(:$match-prefix);
 
     $obj.parse($uri) if $uri.defined;
-    return $obj;
+    $obj;
 }
 
-multi method new(Str :$uri, :$match-prefix) {
-    return self.new($uri, :$match-prefix);
+multi method new(URI:U: :$uri, Bool :$match-prefix) {
+    self.new($uri, :$match-prefix);
 }
 
 method has-scheme(URI:D:) returns Bool:D {
@@ -408,6 +407,7 @@ my regex path-plain {
 method !check-path(
     :$has-authority = $.has-authority,
     :$has-scheme    = $.has-scheme,
+    :$path          = $.path,
     :$source        = $.gist,
 ) {
     my &path-regex := $has-authority ?? &path-authority
@@ -415,8 +415,12 @@ method !check-path(
                    !!                   &path-plain
                    ;
 
-    X::URI::Invalid.new(:$source).throw
-        if $!path !~~ &path-regex;
+    if $path ~~ &path-regex -> $comp {
+        return $comp;
+    }
+    else {
+        X::URI::Invalid.new(:$source).throw
+    }
 }
 
 multi method scheme(URI:D:) returns Scheme:D { $!scheme }
@@ -447,7 +451,17 @@ multi method host(URI:D:) returns Host {
     Nil;
 }
 
-multi method host(URI:D: Host $new) returns Host {
+multi method host(URI:D: Nil) returns Host {
+    with $!authority {
+        self!check-path(:!has-authority,
+            source => self!gister(authority => ''),
+        );
+
+        $!authority = Nil;
+    }
+}
+
+multi method host(URI:D: Str() $new) returns Host {
     with $!authority {
         .host = $new;
     }
@@ -461,10 +475,10 @@ multi method host(URI:D: Host $new) returns Host {
     }
 }
 
-method default-port returns Port {
+method default-port(URI:D:) returns Port {
     URI::DefaultPort.scheme-port($.scheme)
 }
-method default_port returns Port { $.default-port() } # artifact form
+method default_port(URI:D:) returns Port { $.default-port } # artifact form
 
 multi method _port(URI:D:) returns Port {
     return .port with $!authority;
@@ -493,39 +507,45 @@ multi method port(URI:D:) returns Port { $._port // $.default-port }
 
 multi method port(URI:D: |c) returns Port { self._port(|c) }
 
+multi method authority(URI:D:) returns Authority {
+    $!authority;
+}
+
 multi method authority(URI:D: Nil) returns Authority {
+    with $!authority {
+        self!check-path(:!has-authority,
+            source => self!gister(authority => ''),
+        );
+    }
     $!authority = Nil;
 }
 
+multi method authority(URI:D: Authority:D $new) {
+    without $!authority {
+        self!check-path(:has-authority,
+            source => self!gister(authority => ~$new),
+        );
+    }
+    $!authority = $new;
+}
+
 multi method authority(URI:D: Str() $authority) returns Authority:D {
-    if !$.has-authority && $!path !~~ &path-authority {
-        X::URI::Invalid.new(
+    without $!authority {
+        self!check-path(:has-authority,
             source => self!gister(authority => $authority),
-        ).throw
+        );
     }
     $!authority = Authority.new($!grammar, $authority);
 }
 
-multi method authority(URI:D:) is rw returns Authority:D {
-    return-rw $!authority;
-}
-
 multi method path(URI:D:) returns Path:D { $!path }
 
-multi method path(URI:D: Str:D $new) {
-    my &path-regex := $!authority.defined ?? &path-authority
-                   !! $!scheme            ?? &path-scheme
-                   !!                        &path-plain
-                   ;
+multi method path(URI:D: Str() $path) {
+    my $comp = self!check-path(:$path,
+        source => self!gister(path => $path),
+    );
 
-    if $new ~~ &path-regex -> $comp {
-        $!path = Path.new($comp);
-    }
-    else {
-        X::URI::Invalid.new(
-            source => self!gister(path => $new),
-        ).throw
-    }
+    $!path = Path.new($comp);
 }
 
 multi method segments(URI:D:) { $!path.segments }
@@ -552,12 +572,31 @@ method relative {
 
 multi method query(URI:D:) { $!query }
 
-multi method query(URI:D: $new) {
+multi method query(URI:D: Str() $new) {
     $!query.query($new);
     $!query
 }
 
-method path-query {
+multi method query(URI:D: *@new) {
+    $!query.query-form(@new)
+}
+
+multi method query-form(URI:D:) {
+    warn 'query-form is deprecated, use query instead';
+    $!query
+}
+
+multi method query-form(URI:D: |c) {
+    warn 'query-form is deprecated, use query instead';
+    $!query.query-form(|c)
+}
+
+method query_form {
+    warn 'query_form is deprecated, use query intead';
+    $.query
+}
+
+method path-query(URI:D:) {
     $.query ?? "$.path?$.query" !! $.path
 }
 
@@ -566,7 +605,7 @@ method path_query { $.path-query } #artifact form
 multi method fragment(URI:D:) { return-rw $!fragment }
 multi method fragment(URI:D: $new) { $!fragment = $new }
 
-method frag { $.fragment }
+method frag(URI:D:) { $.fragment }
 
 method !gister(
     :$scheme = $.scheme,
@@ -584,8 +623,8 @@ method !gister(
     $s;
 }
 
-method gist() { self!gister }
-method Str() { $.gist }
+multi method gist(URI:D:) { self!gister }
+multi method Str(URI:D:) { $.gist }
 
 # chunks now strongly deprecated
 # it's segments in p5 URI and segment is part of rfc so no more chunks soon!
@@ -598,12 +637,6 @@ method uri {
     warn "uri attribute now deprecated in favor of .grammar.parse_result";
     $!uri;
 }
-
-multi method query-form() { $!query }
-
-multi method query-form(|c) { $!query.query-form(|c) }
-
-method query_form { $.query-form }
 
 =begin pod
 

--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -1,4 +1,4 @@
-unit class URI;
+unit class URI:auth<github:perl6-community-modules>:ver<v0.2>;
 
 use IETF::RFC_Grammar;
 use IETF::RFC_Grammar::URI;

--- a/t/01.t
+++ b/t/01.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 46;
+plan 48;
 
 use URI;
 use URI::Escape;
@@ -16,9 +16,10 @@ is($u.port, '80', 'port');
 is($u.path, '/about/us', 'path');
 is($u.query, 'foo', 'query');
 is($u.frag, 'bar', 'frag');
-is($u.segments, 'about us', 'segments');
-is($u.segments[0], 'about', 'first chunk');
-is($u.segments[1], 'us', 'second chunk');
+is($u.segments.join('/'), '/about/us', 'segments');
+is($u.segments[0], '', 'first chunk');
+is($u.segments[1], 'about', 'second chunk');
+is($u.segments[2], 'us', 'third chunk');
 
 is( ~$u, 'http://example.com:80/about/us?foo#bar',
     'Complete path stringification');
@@ -34,9 +35,9 @@ is($u.port, 443, 'default https port');
 ok(! $u._port.defined, 'no specified port');
 
 $u.parse('/foo/bar/baz');
-is($u.segments, 'foo bar baz', 'segments from absolute path');
+is($u.segments.join('/'), '/foo/bar/baz', 'segments from absolute path');
 $u.parse('foo/bar/baz');
-is($u.segments, 'foo bar baz', 'segments from relative path');
+is($u.segments.join('/'), 'foo/bar/baz', 'segments from relative path');
 
 is($u.segments[0], 'foo', 'first segment');
 is($u.segments[1], 'bar', 'second segment');
@@ -45,7 +46,8 @@ is($u.segments[*-1], 'baz', 'last segment');
 # actual uri parameter not required
 $u = URI.new;
 $u.parse('http://foo.com');
-ok($u.segments == 1 && $u.segments[0] eq '', ".segments return [''] for empty path");
+is-deeply($u.segments, ('',), ".segments return ('',) for empty path");
+is $u.segments.join('/'), '', '.segments joined to empty string';;
 is($u.port, 80, 'default http port');
 
 # test URI parsing with <> or "" and spaces

--- a/t/01.t
+++ b/t/01.t
@@ -70,25 +70,25 @@ ok(! $host_in_grammar<reg-name>.defined, 'grammar detected no registered domain 
 
 $u.parse('http://example.com:80/about?foo=cod&bell=bob#bar');
 is($u.query, 'foo=cod&bell=bob', 'query with form params');
-is($u.query-form<foo>, 'cod', 'query param foo');
-is($u.query_form<foo>, 'cod', 'snake case query param foo');
-is($u.query-form<bell>, 'bob', 'query param bell');
+is($u.query<foo>, 'cod', 'query param foo');
+is($u.query<foo>, 'cod', 'snake case query param foo');
+is($u.query<bell>, 'bob', 'query param bell');
 
 $u.parse('http://example.com:80/about?foo=cod&foo=trout#bar');
-is($u.query-form<foo>[0], 'cod', 'query param foo - el 1');
-is($u.query-form<foo>[1], 'trout', 'query param foo - el 2');
+is($u.query<foo>[0], 'cod', 'query param foo - el 1');
+is($u.query<foo>[1], 'trout', 'query param foo - el 2');
 is($u.frag, 'bar', 'test query and frag capture');
 
 $u.parse('http://example.com:80/about?foo=cod&foo=trout');
-is($u.query-form<foo>[1], 'trout', 'query param foo - el 2 without frag');
+is($u.query<foo>[1], 'trout', 'query param foo - el 2 without frag');
 
 $u.parse('about/perl6uri?foo=cod&foo=trout#bar');
-is($u.query-form<foo>[1], 'trout', 'query param foo - el 2 relative path');
+is($u.query<foo>[1], 'trout', 'query param foo - el 2 relative path');
 
 $u.parse('about/perl6uri?foo=cod&foo=trout');
-is($u.query-form<foo>[1], 'trout', 'query param foo - el 2 relative path without frag');
+is($u.query<foo>[1], 'trout', 'query param foo - el 2 relative path without frag');
 
-throws-like {URI.new('http:://?#?#')}, X::URI::Invalid, 
+throws-like {URI.new('http:://?#?#')}, X::URI::Invalid,
     'Bad URI raises exception x:URI::Invalid';
 
 my $uri-w-js = 'http://example.com } function(var mm){ alert(mm) }';

--- a/t/authority.t
+++ b/t/authority.t
@@ -40,22 +40,22 @@ with $u.authority {
 $u.authority('me@localhost:4321');
 is "$u", 'foo://me@localhost:4321';
 
-$u.authority('');
+$u.authority(Nil);
 is "$u", 'foo:';
 
-throws-like {
-    $u.userinfo('me');
-}, X::URI::Authority::Invalid;
+$u.userinfo('me');
+is "$u", 'foo://me@';
 
-throws-like {
-    $u.port(4321);
-}, X::URI::Authority::Invalid;
+$u.port(4321);
+is "$u", 'foo://me@:4321';
 
 $u.host('localhost');
-is "$u", 'foo://localhost';
-
-$u.userinfo('me');
-$u.port(4321);
 is "$u", 'foo://me@localhost:4321';
+
+$u.authority('');
+is "$u", 'foo://';
+
+$u.authority(Nil);
+is "$u", 'foo:';
 
 done-testing;

--- a/t/authority.t
+++ b/t/authority.t
@@ -1,0 +1,61 @@
+use v6;
+use Test;
+use URI;
+
+my $u = URI.new('foo://me@localhost:4321');
+
+isa-ok $u.authority, URI::Authority;
+ok $u.authority.defined;
+
+with $u.authority {
+    is .userinfo, 'me';
+    is .host, 'localhost';
+    is .port, 4321;
+
+    is "$_", 'me@localhost:4321';
+    is .gist, "$_";
+
+    .userinfo = 'steve';
+    is "$_", 'steve@localhost:4321';
+
+    .host = 'xyz';
+    is "$_", 'steve@xyz:4321';
+
+    .port = 1234;
+    is "$_", 'steve@xyz:1234';
+
+    .userinfo = '';
+    is "$_", 'xyz:1234';
+
+    .userinfo = 'steve';
+    is "$_", 'steve@xyz:1234';
+
+    .userinfo = Nil;
+    is "$_", 'xyz:1234';
+
+    .port = Nil;
+    is "$_", 'xyz';
+}
+
+$u.authority('me@localhost:4321');
+is "$u", 'foo://me@localhost:4321';
+
+$u.authority('');
+is "$u", 'foo:';
+
+throws-like {
+    $u.userinfo('me');
+}, X::URI::Authority::Invalid;
+
+throws-like {
+    $u.port(4321);
+}, X::URI::Authority::Invalid;
+
+$u.host('localhost');
+is "$u", 'foo://localhost';
+
+$u.userinfo('me');
+$u.port(4321);
+is "$u", 'foo://me@localhost:4321';
+
+done-testing;

--- a/t/meta.t
+++ b/t/meta.t
@@ -1,0 +1,15 @@
+#!perl6
+
+use v6;
+use lib 'lib';
+
+use Test;
+use Test::META;
+
+plan 1;
+
+# That's it
+meta-ok();
+
+
+done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -72,4 +72,7 @@ throws-like {
     $u.query-form<bar> = 'bad stuff';
 }, X::Assignment::RO, 'cannot set query-form<> because it is immutable';
 
+$u.fragment = "wubba";
+is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#wubba', 'setting fragment works';
+
 done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -46,33 +46,81 @@ $u.path("/careers/are/good");
 is "$u", 'https://example.com/careers/are/good?foo#bar', 'empty path works';
 is-deeply $u.segments, ('careers', 'are', 'good'), '/careers/are/good has three segments';
 
-$u.query('foo=cod&foo=trout');
-is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
-is $u.query-form<foo>[0], 'cod', 'query form foo.0 is good';
-is $u.query-form<foo>[1], 'trout', 'query form foo.1 is good';
+subtest {
+    $u.query.hash-format = URI::Query::Mixed;
+    $u.query('foo=cod&foo=trout');
+    is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
+    is-deeply $u.query-form<foo>, ('cod', 'trout'), 'query from foo is good';
+    is $u.query-form<foo>[0], 'cod', 'query form foo.0 is good';
+    is $u.query-form<foo>[1], 'trout', 'query form foo.1 is good';
 
-throws-like {
-    $u.query-form<foo>[0] = 'bad stuff';
-}, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+    throws-like {
+        $u.query-form<foo>[0] = 'bad stuff';
+    }, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
 
-throws-like {
-    $u.query-form<foo> = 'bad stuff';
-}, X::Assignment::RO, 'cannot set query-form<> because it is immutable';
+    $u.query-form<foo> = True;
+    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query-form<> to True works';
 
-$u.query-form('bar' => 'lion', 'bar' => 'tiger');
-is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
-is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
-is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
+    $u.query-form('bar' => 'lion', 'bar' => 'tiger');
+    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
+    is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
+    is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
 
-throws-like {
-    $u.query-form<bar>[0] = 'bad stuff';
-}, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+    throws-like {
+        $u.query-form<bar>[0] = 'bad stuff';
+    }, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
 
-throws-like {
-    $u.query-form<bar> = 'bad stuff';
-}, X::Assignment::RO, 'cannot set query-form<> because it is immutable';
+    $u.query-form<bar> = 'ok';
+    is "$u", 'https://example.com/careers/are/good?bar=ok#bar', 'setting query-form<> works';
 
+    $u.query-form<bar> = ('ok', 'andok');
+    is "$u", 'https://example.com/careers/are/good?bar=ok&bar=andok#bar', 'setting query-form<> to list works as expected';
+}, 'hash-format = Mixed';
+
+subtest {
+    $u.query.hash-format = URI::Query::Singles;
+    $u.query('foo=cod&foo=trout');
+    is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
+    is-deeply $u.query-form<foo>, 'trout', 'query from foo is good';
+
+    $u.query-form<foo> = True;
+    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query-form to True works';
+
+    $u.query-form('bar' => 'lion', 'bar' => 'tiger');
+    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
+    is $u.query-form<bar>, 'tiger', 'query form bar is good';
+
+    $u.query-form<bar> = ('ok', 'andok');
+    is "$u", 'https://example.com/careers/are/good?bar=ok%20andok#bar', 'setting query-form<> to list works as expected';
+}, 'hash-format = Singles';
+
+subtest {
+    $u.query.hash-format = URI::Query::Lists;
+    $u.query('foo=cod&foo=trout');
+    is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
+    is-deeply $u.query-form<foo>, $('cod', 'trout'), 'query from foo is good';
+
+    $u.query-form<foo> = True;
+    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query-form<> to True works';
+
+    $u.query-form('bar' => 'lion', 'bar' => 'tiger');
+    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
+    is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
+    is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
+
+    throws-like {
+        $u.query-form<bar>[0] = 'bad stuff';
+    }, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+
+    $u.query-form<bar> = 'ok';
+    is "$u", 'https://example.com/careers/are/good?bar=ok#bar', 'setting query-form<> to single works';
+
+    $u.query-form<bar> = ('ok', 'andok');
+    is "$u", 'https://example.com/careers/are/good?bar=ok&bar=andok#bar', 'setting query-form<> to list works as expected';
+}, 'hash-format = Lists';
+
+$u.query('bar');
 $u.fragment = "wubba";
-is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#wubba', 'setting fragment works';
+is "$u", 'https://example.com/careers/are/good?bar#wubba', 'setting fragment works';
 
 done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -50,73 +50,73 @@ subtest {
     $u.query.hash-format = URI::Query::Mixed;
     $u.query('foo=cod&foo=trout');
     is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
-    is-deeply $u.query-form<foo>, ('cod', 'trout'), 'query from foo is good';
-    is $u.query-form<foo>[0], 'cod', 'query form foo.0 is good';
-    is $u.query-form<foo>[1], 'trout', 'query form foo.1 is good';
+    is-deeply $u.query<foo>, ('cod', 'trout'), 'query from foo is good';
+    is $u.query<foo>[0], 'cod', 'query form foo.0 is good';
+    is $u.query<foo>[1], 'trout', 'query form foo.1 is good';
 
     throws-like {
-        $u.query-form<foo>[0] = 'bad stuff';
-    }, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+        $u.query<foo>[0] = 'bad stuff';
+    }, X::Assignment::RO, 'cannot set query<>[] because it is immutable';
 
-    $u.query-form<foo> = True;
-    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query-form<> to True works';
+    $u.query<foo> = True;
+    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query<> to True works';
 
-    $u.query-form('bar' => 'lion', 'bar' => 'tiger');
-    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
-    is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
-    is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
+    $u.query('bar' => 'lion', 'bar' => 'tiger');
+    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query works';
+    is $u.query<bar>[0], 'lion', 'query form bar.0 is good';
+    is $u.query<bar>[1], 'tiger', 'query form bar.1 is good';
 
     throws-like {
-        $u.query-form<bar>[0] = 'bad stuff';
-    }, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+        $u.query<bar>[0] = 'bad stuff';
+    }, X::Assignment::RO, 'cannot set query<>[] because it is immutable';
 
-    $u.query-form<bar> = 'ok';
-    is "$u", 'https://example.com/careers/are/good?bar=ok#bar', 'setting query-form<> works';
+    $u.query<bar> = 'ok';
+    is "$u", 'https://example.com/careers/are/good?bar=ok#bar', 'setting query<> works';
 
-    $u.query-form<bar> = ('ok', 'andok');
-    is "$u", 'https://example.com/careers/are/good?bar=ok&bar=andok#bar', 'setting query-form<> to list works as expected';
+    $u.query<bar> = ('ok', 'andok');
+    is "$u", 'https://example.com/careers/are/good?bar=ok&bar=andok#bar', 'setting query<> to list works as expected';
 }, 'hash-format = Mixed';
 
 subtest {
     $u.query.hash-format = URI::Query::Singles;
     $u.query('foo=cod&foo=trout');
     is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
-    is-deeply $u.query-form<foo>, 'trout', 'query from foo is good';
+    is-deeply $u.query<foo>, 'trout', 'query from foo is good';
 
-    $u.query-form<foo> = True;
-    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query-form to True works';
+    $u.query<foo> = True;
+    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query to True works';
 
-    $u.query-form('bar' => 'lion', 'bar' => 'tiger');
-    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
-    is $u.query-form<bar>, 'tiger', 'query form bar is good';
+    $u.query('bar' => 'lion', 'bar' => 'tiger');
+    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query works';
+    is $u.query<bar>, 'tiger', 'query form bar is good';
 
-    $u.query-form<bar> = ('ok', 'andok');
-    is "$u", 'https://example.com/careers/are/good?bar=ok%20andok#bar', 'setting query-form<> to list works as expected';
+    $u.query<bar> = ('ok', 'andok');
+    is "$u", 'https://example.com/careers/are/good?bar=ok%20andok#bar', 'setting query<> to list works as expected';
 }, 'hash-format = Singles';
 
 subtest {
     $u.query.hash-format = URI::Query::Lists;
     $u.query('foo=cod&foo=trout');
     is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
-    is-deeply $u.query-form<foo>, $('cod', 'trout'), 'query from foo is good';
+    is-deeply $u.query<foo>, $('cod', 'trout'), 'query from foo is good';
 
-    $u.query-form<foo> = True;
-    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query-form<> to True works';
+    $u.query<foo> = True;
+    is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting query<> to True works';
 
-    $u.query-form('bar' => 'lion', 'bar' => 'tiger');
-    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
-    is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
-    is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
+    $u.query('bar' => 'lion', 'bar' => 'tiger');
+    is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query works';
+    is $u.query<bar>[0], 'lion', 'query form bar.0 is good';
+    is $u.query<bar>[1], 'tiger', 'query form bar.1 is good';
 
     throws-like {
-        $u.query-form<bar>[0] = 'bad stuff';
-    }, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+        $u.query<bar>[0] = 'bad stuff';
+    }, X::Assignment::RO, 'cannot set query<>[] because it is immutable';
 
-    $u.query-form<bar> = 'ok';
-    is "$u", 'https://example.com/careers/are/good?bar=ok#bar', 'setting query-form<> to single works';
+    $u.query<bar> = 'ok';
+    is "$u", 'https://example.com/careers/are/good?bar=ok#bar', 'setting query<> to single works';
 
-    $u.query-form<bar> = ('ok', 'andok');
-    is "$u", 'https://example.com/careers/are/good?bar=ok&bar=andok#bar', 'setting query-form<> to list works as expected';
+    $u.query<bar> = ('ok', 'andok');
+    is "$u", 'https://example.com/careers/are/good?bar=ok&bar=andok#bar', 'setting query<> to list works as expected';
 }, 'hash-format = Lists';
 
 $u.query('bar');

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -51,10 +51,25 @@ is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting 
 is $u.query-form<foo>[0], 'cod', 'query form foo.0 is good';
 is $u.query-form<foo>[1], 'trout', 'query form foo.1 is good';
 
+throws-like {
+    $u.query-form<foo>[0] = 'bad stuff';
+}, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+
+throws-like {
+    $u.query-form<foo> = 'bad stuff';
+}, X::Assignment::RO, 'cannot set query-form<> because it is immutable';
+
 $u.query-form('bar' => 'lion', 'bar' => 'tiger');
 is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
 is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
 is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
 
+throws-like {
+    $u.query-form<bar>[0] = 'bad stuff';
+}, X::Assignment::RO, 'cannot set query-form<>[] because it is immutable';
+
+throws-like {
+    $u.query-form<bar> = 'bad stuff';
+}, X::Assignment::RO, 'cannot set query-form<> because it is immutable';
 
 done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -36,15 +36,37 @@ ok !$u._port.defined, 'setting authority clears port';
 
 $u.path("/");
 is "$u", 'https://example.com/?foo#bar', 'setting path works';
-is-deeply $u.segments, ('',), '/ has empty segments';
+is-deeply $u.segments, ('',''), '/ has empty segments';
 
 $u.path("");
 is "$u", 'https://example.com?foo#bar', 'empty path works';
-is-deeply $u.segments, ('',), '"" has empty segments';
+is-deeply $u.segments, ('', ), '"" has one empty segment segments';
 
 $u.path("/careers/are/good");
 is "$u", 'https://example.com/careers/are/good?foo#bar', 'empty path works';
-is-deeply $u.segments, ('careers', 'are', 'good'), '/careers/are/good has three segments';
+is-deeply $u.segments, ('', 'careers', 'are', 'good'), '/careers/are/good has three segments';
+
+$u.segments(«"" foo bar baz»);
+is $u.path, '/foo/bar/baz';
+is "$u", 'https://example.com/foo/bar/baz?foo#bar', 'setting segments via list works';
+is-deeply $u.segments, ('', 'foo', 'bar', 'baz'), 'settings segments gets same back';
+
+throws-like {
+    $u.segments("/");
+}, X::URI::Path::Invalid;
+
+throws-like {
+    $u.segments(</>);
+}, X::URI::Path::Invalid;
+
+throws-like {
+    $u.segments(<careers are good>);
+}, X::URI::Path::Invalid;
+
+$u.segments('', 'careers', 'are', 'good');
+is $u.path, '/careers/are/good';
+is "$u", 'https://example.com/careers/are/good?foo#bar', 'setting segments via slurpy works';
+is-deeply $u.segments, ('', 'careers', 'are', 'good'), 'settings segments gets same back';
 
 subtest {
     $u.query.hash-format = URI::Query::Mixed;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+use URI;
+use IETF::RFC_Grammar::URI;
+
+cmp-ok 'http', '~~', URI::Scheme, 'URI::Scheme matches http';
+cmp-ok '', '~~', URI::Scheme, 'URI::Scheme matches ""';
+cmp-ok '-asdf', '!~~', URI::Scheme, 'URI::Scheme refused to match -asdf';
+
+my $u = URI.new('http://example.com:80/about/us?foo#bar');
+
+$u.scheme = 'https';
+$u.port   = 443;
+is "$u", 'https://example.com:443/about/us?foo#bar', 'modified URI looks good';
+
+$u.port = Nil;
+is "$u", 'https://example.com/about/us?foo#bar', 'URI with no port looks good';
+
+$u._port = 567;
+is "$u", 'https://example.com:567/about/us?foo#bar', 'setting _port works too';
+
+$u._port = Nil;
+is "$u", 'https://example.com/about/us?foo#bar', 'clearing with _port works too';
+
+$u.authority = "larry@perl6.org:1234";
+is "$u", 'https://larry@perl6.org:1234/about/us?foo#bar', 'setting authority works';
+is $u.userinfo, 'larry', 'setting authority set userinfo';
+is $u.host, 'perl6.org', 'setting authority set host';
+is $u.port, 1234, 'setting authority set port';
+
+$u.authority = "example.com";
+is "$u", 'https://example.com/about/us?foo#bar', 'setting authority with only a host works';
+is $u.userinfo, '', 'setting authority clears userinfo';
+is $u.host, 'example.com', 'setting authority set host';
+ok !$u._port.defined, 'setting authority clears port';
+
+$u.path = "/";
+is "$u", 'https://example.com/?foo#bar', 'setting path works';
+is-deeply $u.segments, $(''), '/ has empty segments';
+
+$u.path = "";
+is "$u", 'https://example.com?foo#bar', 'empty path works';
+is-deeply $u.segments, $(''), '"" has empty segments';
+
+$u.path = "/careers/are/good";
+is "$u", 'https://example.com/careers/are/good?foo#bar', 'empty path works';
+is-deeply $u.segments, $('careers', 'are', 'good'), '/careers/are/good has three segments';
+
+done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -9,17 +9,17 @@ cmp-ok '-asdf', '!~~', URI::Scheme, 'URI::Scheme refused to match -asdf';
 
 my $u = URI.new('http://example.com:80/about/us?foo#bar');
 
-$u.scheme = 'https';
+$u.scheme('https');
 $u.port(443);
 is "$u", 'https://example.com:443/about/us?foo#bar', 'modified URI looks good';
 
 $u.port(Nil);
 is "$u", 'https://example.com/about/us?foo#bar', 'URI with no port looks good';
 
-$u._port = 567;
+$u._port(567);
 is "$u", 'https://example.com:567/about/us?foo#bar', 'setting _port works too';
 
-$u._port = Nil;
+$u._port(Nil);
 is "$u", 'https://example.com/about/us?foo#bar', 'clearing with _port works too';
 
 $u.authority("larry@perl6.org:1234");
@@ -122,5 +122,8 @@ subtest {
 $u.query('bar');
 $u.fragment = "wubba";
 is "$u", 'https://example.com/careers/are/good?bar#wubba', 'setting fragment works';
+
+$u.fragment("hello");
+is "$u", 'https://example.com/careers/are/good?bar#hello', 'setting fragment works';
 
 done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -10,10 +10,10 @@ cmp-ok '-asdf', '!~~', URI::Scheme, 'URI::Scheme refused to match -asdf';
 my $u = URI.new('http://example.com:80/about/us?foo#bar');
 
 $u.scheme = 'https';
-$u.port   = 443;
+$u.port(443);
 is "$u", 'https://example.com:443/about/us?foo#bar', 'modified URI looks good';
 
-$u.port = Nil;
+$u.port(Nil);
 is "$u", 'https://example.com/about/us?foo#bar', 'URI with no port looks good';
 
 $u._port = 567;
@@ -22,28 +22,28 @@ is "$u", 'https://example.com:567/about/us?foo#bar', 'setting _port works too';
 $u._port = Nil;
 is "$u", 'https://example.com/about/us?foo#bar', 'clearing with _port works too';
 
-$u.authority = "larry@perl6.org:1234";
+$u.authority("larry@perl6.org:1234");
 is "$u", 'https://larry@perl6.org:1234/about/us?foo#bar', 'setting authority works';
 is $u.userinfo, 'larry', 'setting authority set userinfo';
 is $u.host, 'perl6.org', 'setting authority set host';
 is $u.port, 1234, 'setting authority set port';
 
-$u.authority = "example.com";
+$u.authority("example.com");
 is "$u", 'https://example.com/about/us?foo#bar', 'setting authority with only a host works';
 is $u.userinfo, '', 'setting authority clears userinfo';
 is $u.host, 'example.com', 'setting authority set host';
 ok !$u._port.defined, 'setting authority clears port';
 
-$u.path = "/";
+$u.path("/");
 is "$u", 'https://example.com/?foo#bar', 'setting path works';
-is-deeply $u.segments, $(''), '/ has empty segments';
+is-deeply $u.segments, ('',), '/ has empty segments';
 
-$u.path = "";
+$u.path("");
 is "$u", 'https://example.com?foo#bar', 'empty path works';
-is-deeply $u.segments, $(''), '"" has empty segments';
+is-deeply $u.segments, ('',), '"" has empty segments';
 
-$u.path = "/careers/are/good";
+$u.path("/careers/are/good");
 is "$u", 'https://example.com/careers/are/good?foo#bar', 'empty path works';
-is-deeply $u.segments, $('careers', 'are', 'good'), '/careers/are/good has three segments';
+is-deeply $u.segments, ('careers', 'are', 'good'), '/careers/are/good has three segments';
 
 done-testing;

--- a/t/mutate.t
+++ b/t/mutate.t
@@ -46,4 +46,15 @@ $u.path("/careers/are/good");
 is "$u", 'https://example.com/careers/are/good?foo#bar', 'empty path works';
 is-deeply $u.segments, ('careers', 'are', 'good'), '/careers/are/good has three segments';
 
+$u.query('foo=cod&foo=trout');
+is "$u", 'https://example.com/careers/are/good?foo=cod&foo=trout#bar', 'setting query works';
+is $u.query-form<foo>[0], 'cod', 'query form foo.0 is good';
+is $u.query-form<foo>[1], 'trout', 'query form foo.1 is good';
+
+$u.query-form('bar' => 'lion', 'bar' => 'tiger');
+is "$u", 'https://example.com/careers/are/good?bar=lion&bar=tiger#bar', 'setting query-form works';
+is $u.query-form<bar>[0], 'lion', 'query form bar.0 is good';
+is $u.query-form<bar>[1], 'tiger', 'query form bar.1 is good';
+
+
 done-testing;

--- a/t/path.t
+++ b/t/path.t
@@ -2,10 +2,17 @@ use v6;
 use Test;
 use URI;
 
-my $q = URI.new('foo:a/b/c');
+my $q = URI.new('foo:/a/b/c');
 isa-ok $q.path, URI::Path;
 ok $q.path.defined;
 
+with $q.path {
+    is $_, "/a/b/c";
+    is .path, "/a/b/c";
+    is-deeply .segments, $('', 'a', 'b', 'c');
+}
+
+$q.path('a/b/c');
 with $q.path {
     is $_, "a/b/c";
     is .path, "a/b/c";

--- a/t/path.t
+++ b/t/path.t
@@ -1,0 +1,37 @@
+use v6;
+use Test;
+use URI;
+
+my $q = URI.new('foo:a/b/c');
+isa-ok $q.path, URI::Path;
+ok $q.path.defined;
+
+with $q.path {
+    is $_, "a/b/c";
+    is .path, "a/b/c";
+    is-deeply .segments, $('a', 'b', 'c');
+}
+
+# with auth, path starting with / is required
+throws-like {
+    $q.host('localhost');
+}, X::URI::Invalid;
+
+$q.path('/a/b/c');
+lives-ok {
+    $q.host('localhost');
+};
+is "$q", 'foo://localhost/a/b/c';
+
+$q.host('');
+is "$q", 'foo:///a/b/c';
+
+$q.authority(Nil);
+is "$q", 'foo:/a/b/c';
+
+# without auth first segment after / must be non-zero length
+throws-like {
+    $q.path('//a/b/c');
+}, X::URI::Invalid;
+
+done-testing;

--- a/t/query.t
+++ b/t/query.t
@@ -1,0 +1,193 @@
+use v6;
+use Test;
+use URI :split-query;
+
+constant $qs = 'foo=1&bar=2&foo=3&baz';
+
+subtest {
+    my @q = split-query('');
+    is-deeply @q, [];
+}, 'split-query of empty string';
+
+subtest {
+    my @q = split-query($qs);
+    is-deeply @q, [foo => '1', bar => '2', foo => '3', baz => True];
+}, 'split-query to array';
+
+subtest {
+    my %q = split-query($qs, hash-format => URI::Query::Mixed);
+    is-deeply %q, %(foo => ['1', '3'], bar => '2', baz => True);
+}, 'split-query to mixed hash';
+
+subtest {
+    my %q = split-query($qs, hash-format => URI::Query::Singles);
+    is-deeply %q, %(foo => '3', bar => '2', baz => True);
+}, 'split-query to singles hash';
+
+subtest {
+    my %q = split-query($qs, hash-format => URI::Query::Lists);
+    is-deeply %q, %(foo => ['1', '3'], bar => ['2'], baz => [ True ]);
+}, 'split-query to lists hash';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    is "$q", 'foo=1&bar=2&foo=3&baz', 'query is cached';
+
+    is $q<baz>, True, 'query baz is True';
+    $q<baz> = True;
+    is "$q", 'foo=1&bar=2&foo=3&baz=', 'query is recomputed';
+}, 'query caching';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    is $q[0].key, 'foo';
+    is $q[0].value, '1';
+    is $q[1].key, 'bar';
+    is $q[1].value, '2';
+    is $q[2].key, 'foo';
+    is $q[2].value, '3';
+    is $q[3].key, 'baz';
+    is $q[3].value, True;
+
+    is $q[$_]:exists, True for ^3;
+    is $q[4]:exists, False;
+
+    $q[0] = 'qux' => 4;
+
+    is "$q", "qux=4&bar=2&foo=3&baz=";
+
+    my $bar = $q[1]:delete;
+    is $bar.key, 'bar';
+    is $bar.value, '2';
+
+    is "$q", "qux=4&foo=3&baz=";
+}, 'array-ish bits';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    is-deeply $q<foo>, $('1', '3');
+    is-deeply $q<bar>, $('2',);
+    is-deeply $q<baz>, $(True,);
+
+    is $q{$_}:exists, True for <foo bar baz>;
+    is $q<qux>:exists, False;
+
+    my $foo = $q<foo>:delete;
+    is $foo, $('1', '3');
+    is "$q", 'bar=2&baz=';
+
+    $q<foo> = '4';
+
+    is "$q", 'bar=2&baz=&foo=4';
+}, 'hash-ish lists bits';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    is-deeply $q.keys, <foo bar foo baz>;
+    is-deeply $q.values, $('1', '2', '3', True);
+    is-deeply $q.kv, $('foo', '1', 'bar', '2', 'foo', '3', 'baz', True);
+    is-deeply [|$q.pairs], [foo => '1', bar => '2', foo => '3', baz => True];
+
+    is $q.elems, 4;
+    is $q.end, 3;
+
+    is +$q, 4;
+
+    is "$q", "foo=1&bar=2&foo=3&baz";
+    is $q.gist, "$q";
+    is $q.Str, $q.gist;
+}, 'iterator methods';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    my $baz = $q.pop;
+    is $baz.key, 'baz';
+    is $baz.value, True;
+    is "$q", "foo=1&bar=2&foo=3";
+}, 'pop';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    $q.push: 'foo' => 4, 'foo' => 5;
+    is "$q", 'foo=1&bar=2&foo=3&baz=&foo=4&foo=5';
+}, 'push';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    my @more-foo = 'foo' => 4, 'foo' => 5;
+    $q.append: @more-foo;
+    is "$q", 'foo=1&bar=2&foo=3&baz=&foo=4&foo=5';
+}, 'append';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    my $foo = $q.shift;
+    is $foo.key, 'foo';
+    is $foo.value, '1';
+    is "$q", "bar=2&foo=3&baz=";
+}, 'shift';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    $q.unshift: 'foo' => 4, 'foo' => 5;
+    is "$q", 'foo=4&foo=5&foo=1&bar=2&foo=3&baz=';
+}, 'unshift';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    my @more-foo = 'foo' => 4, 'foo' => 5;
+    $q.prepend: @more-foo;
+    is "$q", 'foo=4&foo=5&foo=1&bar=2&foo=3&baz=';
+}, 'prepend';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    my @more-foo = 'foo' => 4, 'foo' => 5;
+    $q.splice: 1, 2, @more-foo;
+    is "$q", 'foo=1&foo=4&foo=5&baz=';
+}, 'splice';
+
+subtest {
+    my $q = URI::Query.new($qs);
+
+    is ?$q, True;
+    $q.query('');
+    is ?$q, False;
+}, 'Bool';
+
+subtest {
+    my $q = URI::Query.new;
+
+    is "$q", '';
+    is $q.query , '';
+
+    $q.query($qs);
+    is "$q", $qs;
+    is $q.query, $qs;
+
+    $q<baz> = True;
+    is "$q", "foo=1&bar=2&foo=3&baz=";
+    is $q.query, "foo=1&bar=2&foo=3&baz=";
+}, 'query';
+
+subtest {
+    my $q = URI::Query.new;
+
+    is-deeply [|$q.query-form], [];
+
+    $q.query-form('foo' => 1, 'bar' => 2, 'foo' => 3, 'baz' => True);
+    is "$q", "foo=1&bar=2&foo=3&baz=";
+}, 'query-form';
+
+done-testing;

--- a/t/query.t
+++ b/t/query.t
@@ -15,6 +15,16 @@ subtest {
 }, 'split-query to array';
 
 subtest {
+    my @q = split-query($qs, :!hash-format);
+    is-deeply @q, [foo => '1', bar => '2', foo => '3', baz => True];
+}, 'split-query to array (boolean :!hash-format)';
+
+subtest {
+    my %q = split-query($qs, :hash-format);
+    is-deeply %q, %(foo => ['1', '3'], bar => ['2'], baz => [ True ]);
+}, 'split-query to lists hash (boolean :hash-format)';
+
+subtest {
     my %q = split-query($qs, hash-format => URI::Query::Mixed);
     is-deeply %q, %(foo => ['1', '3'], bar => '2', baz => True);
 }, 'split-query to mixed hash';

--- a/t/rfc-3986-examples.t
+++ b/t/rfc-3986-examples.t
@@ -10,8 +10,8 @@ is($u.path, '/rfc/rfc1808.txt', 'ftp path');
 
 $u.parse('http://www.ietf.org/rfc/rfc2396.txt');
 is($u.scheme, 'http', 'http scheme');
-is($u.host, 'www.ietf.org', 'http host'); 
-is($u.path, '/rfc/rfc2396.txt', 'http path'); 
+is($u.host, 'www.ietf.org', 'http host');
+is($u.path, '/rfc/rfc2396.txt', 'http path');
 
 $u.parse('ldap://[2001:db8::7]/c=GB?objectClass?one');
 is($u.scheme, 'ldap', 'ldap scheme');
@@ -36,6 +36,11 @@ is($u.scheme, 'telnet', 'telnet scheme');
 is($u.authority, '192.0.2.16:80', 'telnet authority');
 is($u.host, '192.0.2.16', 'telnet host');
 is($u.port, '80', 'telnet port');
+
+$u.parse("file:///etc/hosts");
+is $u.scheme, 'file', 'filescheme';
+ok !$u.authority.defined, 'no authority';
+is $u.path, '/etc/hosts';
 
 $u.parse('urn:oasis:names:specification:docbook:dtd:xml:4.1.2');
 is($u.scheme, 'urn', 'urn scheme');

--- a/t/rfc-3986-examples.t
+++ b/t/rfc-3986-examples.t
@@ -1,6 +1,6 @@
 use v6;
 use Test;
-plan 22;
+plan 25;
 
 use URI;
 my $u = URI.new('ftp://ftp.is.co.za/rfc/rfc1808.txt', :validating<1>);
@@ -38,8 +38,8 @@ is($u.host, '192.0.2.16', 'telnet host');
 is($u.port, '80', 'telnet port');
 
 $u.parse("file:///etc/hosts");
-is $u.scheme, 'file', 'filescheme';
-ok !$u.authority.defined, 'no authority';
+is $u.scheme, 'file', 'file scheme';
+ok $u.authority.defined, 'no authority';
 is $u.path, '/etc/hosts';
 
 $u.parse('urn:oasis:names:specification:docbook:dtd:xml:4.1.2');


### PR DESCRIPTION
This is a fairly major patch that adds mutators to URI (see issue #27) and also fixes how the query-form is returns (see issue #33).

It adds new class and types for maintaining the correctness of the URI while modified and to provide piecewise encapsulation of data. This includes adding a number of subsets for validating the components and the URI::Query, URI::Authority, and URI::Path classes for maintaining state specific to those components of the URI.

The most controversial decision I think I made is a preference for what I call "heavy mutators" which are defined as methods on the class rather than as assignment. For example,

```perl6
my $u = URI.new("mailto:bob@example.com");
$u.path("steve@example.com");
```

This is due to the fact that most of the mutators have to do some amount of specialized validation, conditional object construction, and cross-checking with other fields in order to keep the state of URI pure. The only way to achieve this with assignment is to use a lot of Proxy objects, but I do not believe this to be a good practice. (Historically, I have done just this on other work I've done and I believe that has often been a mistake.)

The other controversial decision I made is to deprecate `query-form` and make hash-like use of query data always work with lists of strings rather than a mixed form (see #33). However, because of how lists work in Perl 6, I believe there's a very good chance most existing uses of `query-form` will work correctly despite this. If not, there is a hash-format option for quickly recovering the old behavior. I will also say that I'd be willing to modify the code so that the deprecated `query-form` method always returns the mixed form and recommend everyone update their code to use `query` in the future.

I have expanded the test suite quite a bit and have attempted to thoroughly document everything URI is capable of doing going forward.