### PR TITLE
Expect Failure from Grammar.parse

### DIFF
--- a/lib/URI.pm
+++ b/lib/URI.pm
@@ -38,7 +38,7 @@ method parse (Str $str, :$match-prefix) {
         $!grammar.subparse($c_str);
     }
     else {
-        $!grammar.parse($c_str);
+        try $!grammar.parse($c_str);
     }
 
     # hacky but for the time being an improvement


### PR DESCRIPTION
This is a fix for recent rakudo change
(9501edae4f73a970e3270e3b0336a7b3045d3329)

Note that the change will be reverted, but it does not hurt to adapt
URI module anyway.